### PR TITLE
Fix atomic-number handling in lammps interface

### DIFF
--- a/franken/autotune/cli.py
+++ b/franken/autotune/cli.py
@@ -506,7 +506,8 @@ def build_parser(return_groups: bool = False):
     )
     parser.add_argument(
         "--global-scaling",
-        action="store_false",
+        action="store_true",
+        default=False,
         help=get_field_docstring(AutotuneConfig, "scale_by_species"),
     )
     parser.add_argument(

--- a/franken/backbones/utils.py
+++ b/franken/backbones/utils.py
@@ -201,7 +201,10 @@ def load_checkpoint(gnn_config: BackboneConfig) -> torch.nn.Module:
             logger.error(err_msg, exc_info=import_err)
             raise
         return FrankenMACE.load_from_checkpoint(
-            str(ckpt_path), gnn_backbone_id=gnn_backbone_id, **gnn_config_dict
+            str(ckpt_path),
+            gnn_backbone_id=gnn_backbone_id,
+            map_location="cpu",
+            **gnn_config_dict,
         )
     elif backbone_family == "sevenn":
         try:

--- a/franken/calculators/lammps_calc.py
+++ b/franken/calculators/lammps_calc.py
@@ -54,8 +54,10 @@ class LammpsFrankenCalculator(torch.nn.Module):
             of the appropriate shape filled with zeros. Make sure that
             the chosen MD method does not depend on these quantities.
         """
-        # node_attrs is a one-hot representation of the atom types
-        atom_nums = torch.nonzero(data["node_attrs"])[:, 1] + 1
+        # node_attrs is a one-hot representation of the atom types. atom_nums should be the actual atomic numbers!
+        # we rely on correct sorting. This is the same as in MACE.
+        atom_nums = self.atomic_numbers[torch.argmax(data["node_attrs"], dim=1)]
+
         franken_data = Configuration(
             atom_pos=data["positions"].double(),
             atomic_numbers=atom_nums,

--- a/franken/calculators/lammps_calc.py
+++ b/franken/calculators/lammps_calc.py
@@ -57,12 +57,12 @@ class LammpsFrankenCalculator(torch.nn.Module):
         # node_attrs is a one-hot representation of the atom types
         atom_nums = torch.nonzero(data["node_attrs"])[:, 1] + 1
         franken_data = Configuration(
-            atom_pos=data["positions"],
+            atom_pos=data["positions"].double(),
             atomic_numbers=atom_nums,
             natoms=torch.tensor(
                 len(atom_nums), dtype=torch.int32, device=atom_nums.device
             ).view(1),
-            node_attrs=data["node_attrs"],
+            node_attrs=data["node_attrs"].double(),
             edge_index=data["edge_index"],
             shifts=data["shifts"],
             unit_shifts=data["unit_shifts"],

--- a/franken/data/fairchem.py
+++ b/franken/data/fairchem.py
@@ -15,7 +15,7 @@ class FairchemAtomsDataset(BaseAtomsDataset):
         split: str,
         num_random_subsamples: int | None = None,
         subsample_rng: int | None = None,
-        gnn_backbone_id: str | None = None,
+        gnn_backbone_id: str | torch.nn.Module | None = None,
         cutoff=6.0,
         max_num_neighbors=200,
         precompute=True,
@@ -44,7 +44,11 @@ class FairchemAtomsDataset(BaseAtomsDataset):
                 self.ase_atoms, disable_tqdm=dist_utils.get_rank() != 0
             )
 
-    def load_info_from_gnn_config(self, gnn_backbone_id: str):
+    def load_info_from_gnn_config(self, gnn_backbone_id: str | torch.nn.Module):
+        if not isinstance(gnn_backbone_id, str):
+            raise ValueError(
+                "Backbone path must be provided instead of the preloaded model."
+            )
         ckpt_path = get_checkpoint_path(gnn_backbone_id)
         model = torch.load(ckpt_path, map_location="cpu", weights_only=False)
         model_cfg = model["config"]["model"]

--- a/franken/data/mace.py
+++ b/franken/data/mace.py
@@ -53,7 +53,7 @@ class MACEAtomsDataset(BaseAtomsDataset):
         split: str,
         num_random_subsamples: int | None = None,
         subsample_rng: int | None = None,
-        gnn_backbone_id: str | None = None,
+        gnn_backbone_id: str | torch.nn.Module | None = None,
         z_table: AtomicNumberTable | None = None,
         cutoff=6.0,
         precompute=True,
@@ -72,11 +72,14 @@ class MACEAtomsDataset(BaseAtomsDataset):
                 split_name=self.split,
             )
 
-    def load_info_from_gnn_config(self, gnn_backbone_id: str):
-        ckpt_path = get_checkpoint_path(gnn_backbone_id)
-        mace_gnn = torch_load_maybejit(
-            ckpt_path, map_location="cpu", weights_only=False
-        )
+    def load_info_from_gnn_config(self, gnn_backbone_id: str | torch.nn.Module):
+        if isinstance(gnn_backbone_id, str):
+            ckpt_path = get_checkpoint_path(gnn_backbone_id)
+            mace_gnn = torch_load_maybejit(
+                ckpt_path, map_location="cpu", weights_only=False
+            )
+        else:
+            mace_gnn = gnn_backbone_id
         z_table = AtomicNumberTable([z.item() for z in mace_gnn.atomic_numbers])
         cutoff = mace_gnn.r_max.item()
         del mace_gnn

--- a/franken/data/sevenn.py
+++ b/franken/data/sevenn.py
@@ -75,7 +75,7 @@ class SevennAtomsDataset(BaseAtomsDataset):
         split: str,
         num_random_subsamples: int | None = None,
         subsample_rng: int | None = None,
-        gnn_backbone_id: str | None = None,
+        gnn_backbone_id: str | torch.nn.Module | None = None,
         cutoff: float = 6.0,
         precompute=True,
     ):
@@ -100,7 +100,11 @@ class SevennAtomsDataset(BaseAtomsDataset):
                 split_name=self.split,
             )
 
-    def load_info_from_gnn_config(self, gnn_backbone_id: str):
+    def load_info_from_gnn_config(self, gnn_backbone_id: str | torch.nn.Module):
+        if not isinstance(gnn_backbone_id, str):
+            raise ValueError(
+                "Backbone path must be provided instead of the preloaded model."
+            )
         ckpt_path = get_checkpoint_path(gnn_backbone_id)
         checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=False)
         config = checkpoint["config"]

--- a/franken/metrics/functions.py
+++ b/franken/metrics/functions.py
@@ -30,14 +30,13 @@ class EnergyMAE(BaseMetric):
             raise NotImplementedError(
                 "At the moment, target's forces are required to get the number of atoms in the configuration."
             )
-        if torch.any(torch.isnan(predictions.energy)):
-            return
         num_atoms = targets.forces.shape[-2]
         num_samples = 1
         if targets.energy.ndim > 0:
             num_samples = targets.energy.shape[0]
 
         error = 1000 * torch.abs(targets.energy - predictions.energy) / num_atoms
+
         self.buffer_add(error, num_samples=num_samples)
 
 
@@ -54,14 +53,13 @@ class EnergyRMSE(BaseMetric):
             raise NotImplementedError(
                 "At the moment, target's forces are required to get the number of atoms in the configuration."
             )
-        if torch.any(torch.isnan(predictions.energy)):
-            return
         num_atoms = targets.forces.shape[-2]
         num_samples = 1
         if targets.energy.ndim > 0:
             num_samples = targets.energy.shape[0]
 
         error = torch.square((targets.energy - predictions.energy) / num_atoms)
+
         self.buffer_add(error, num_samples=num_samples)
 
     def compute(self, reset: bool = True) -> torch.Tensor:
@@ -91,8 +89,6 @@ class ForcesMAE(BaseMetric):
     def update(self, predictions: Target, targets: Target) -> None:
         if targets.forces is None or predictions.forces is None:
             raise AttributeError("Forces must be specified to compute the MAE.")
-        if torch.any(torch.isnan(predictions.forces)):
-            return
         num_samples = 1
         if targets.forces.ndim > 2:
             num_samples = targets.forces.shape[0]
@@ -101,6 +97,7 @@ class ForcesMAE(BaseMetric):
 
         error = 1000 * torch.abs(targets.forces - predictions.forces)
         error = error.mean(dim=(-1, -2))  # Average over atoms and components
+
         self.buffer_add(error, num_samples=num_samples)
 
 
@@ -115,8 +112,6 @@ class ForcesRMSE(BaseMetric):
     def update(self, predictions: Target, targets: Target) -> None:
         if targets.forces is None or predictions.forces is None:
             raise AttributeError("Forces must be specified to compute the MAE.")
-        if torch.any(torch.isnan(predictions.forces)):
-            return
         num_samples = 1
         if targets.forces.ndim > 2:
             num_samples = targets.forces.shape[0]
@@ -125,6 +120,7 @@ class ForcesRMSE(BaseMetric):
 
         error = torch.square(targets.forces - predictions.forces)
         error = error.mean(dim=(-1, -2))  # Average over atoms and components
+
         self.buffer_add(error, num_samples=num_samples)
 
     def compute(self, reset: bool = True) -> torch.Tensor:
@@ -156,8 +152,6 @@ class ForcesRMSE2(BaseMetric):
     def update(self, predictions: Target, targets: Target) -> None:
         if targets.forces is None or predictions.forces is None:
             raise AttributeError("Forces must be specified to compute the MAE.")
-        if torch.any(torch.isnan(predictions.forces)):
-            return
         num_samples = 1
         if targets.forces.ndim > 2:
             num_samples = targets.forces.shape[0]
@@ -186,8 +180,6 @@ class ForcesCosineSimilarity(BaseMetric):
         num_samples = 1
         assert targets.forces is not None
         assert predictions.forces is not None
-        if torch.any(torch.isnan(predictions.forces)):
-            return
         if targets.forces.ndim > 2:
             num_samples = targets.forces.shape[0]
         elif targets.forces.ndim < 2:


### PR DESCRIPTION
LAMMPS uses sequential "atomic numbers" while in MACE and in Franken real atomic numbers are used.