### PR TITLE
Expose best-model selection metrics in autotune CLI

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,7 @@ Advantages of Franken
    topics/installation.md
    topics/minimal_example.md
    topics/model_registry.md
+   topics/metrics.md
    topics/multigpu.md
    topics/lammps.md
 

--- a/docs/topics/metrics.md
+++ b/docs/topics/metrics.md
@@ -1,0 +1,56 @@
+# Metrics
+
+This page summarizes:
+- the objective optimized by **franken** during fitting
+- which evaluation metrics are available
+- how autotune selects the best model.
+
+## Training Objective (Loss)
+
+During fitting, franken solves a weighted least-squares problem combining mean square error (MSE) on energy and forces:
+
+$$
+\mathcal{L}(\mathbf{w}) =
+(1-\alpha)\,\mathrm{MSE}\!\left(E(\mathbf{w}), E^{\star}\right)
+\;+\;
+\alpha\,\mathrm{MSE}\!\left(F(\mathbf{w}), F^{\star}\right)
+$$
+
+where the hyperparameter  `force_weight` (between 0 and 1) controls the relative contribution. In addition, there is also a ridge regularization with weight `l2_penalty`.
+
+## Evaluation Metrics
+
+The following metrics can be calculated: 
+* `energy_MAE`, `energy_RMSE`, `forces_MAE`, `forces_RMSE`, `forces_cosim`, `forces_MAE_species`, `forces_RMSE_species`.
+
+They can be customized using the autotune configuration: 
+
+```bash
+franken.autotune \
+  ... \
+  --metrics energy_MAE forces_MAE forces_MAE_species \
+  --best-model-selection energy_MAE forces_MAE
+```
+
+```python
+from franken.config import AutotuneConfig
+
+cfg = AutotuneConfig(
+    ...,
+    metrics=["energy_MAE", "forces_MAE_species"],
+    best_model_selection=["energy_MAE, forces_MAE"]
+)
+```
+
+When using species-resolved metrics (`forces_MAE_species`, `forces_RMSE_species`), the logs do not store a single scalar, but rather a value per each atomic number `Z` (`..._<Z>`) and the average of the metric per species (`..._average`)
+
+## Best-Model Selection in Autotune
+
+Autotune chooses the best model from the metrics in `best_model_selection` by (i) building the Pareto frontier using a list of metrics and (ii) among Pareto-efficient models, minimizing the p-norm (`p=1`).
+
+The metric(s) which are used to perfom the selection can be customized in the CLI using `--best-model-selection` (`best_model_selection` for the APIs).
+
+
+Notes:
+- This affects model ranking only (`best.json` / `best_ckpt.pt`), not the training loss.
+- To use species-resolved metrics, use `*_average` (or an explicit `*_Z`) in `best_model_selection`.

--- a/docs/topics/metrics.md
+++ b/docs/topics/metrics.md
@@ -37,8 +37,8 @@ from franken.config import AutotuneConfig
 
 cfg = AutotuneConfig(
     ...,
-    metrics=["energy_MAE", "forces_MAE_species"],
-    best_model_selection=["energy_MAE, forces_MAE"]
+    metrics=["energy_MAE", "forces_MAE", "forces_MAE_species"],
+    best_model_selection=["energy_MAE", "forces_MAE"]
 )
 ```
 

--- a/docs/topics/minimal_example.md
+++ b/docs/topics/minimal_example.md
@@ -5,24 +5,17 @@
 Franken models can be easily trained using the autotune CLI tool:
 ```bash
 franken.autotune \
-    --train-path train.xyz \
-    --val-path val.xyz \
-    --backbone=mace --mace.path-or-id "mace_mp/small" --mace.interaction-block 2 \
-    --rf=ms-gaussian --ms-gaussian.num-rf 4096 --ms-gaussian.length-scale-num 5\
+    --train-path train.xyz --val-path val.xyz \
+    --backbone=mace --mace.path-or-id "mace_mp/small" \
+    --rf=ms-gaussian --ms-gaussian.num-rf 8192 --ms-gaussian.length-scale-num 5\
     --ms-gaussian.length-scale-low 1  --ms-gaussian.length-scale-high 32 \
-    --force-weight=0.99 \
-    --l2-penalty="(-10, -6, 5, log)" \
-    --metrics energy_MAE forces_MAE forces_MAE_species \
-    --jac-chunk-size "auto"
 ```
-
-You can customize which evaluation metrics are computed via `--metrics`. If omitted, a default set of metrics is computed.
 
 This will create a folder `run_DATE_TIME_...` containing:
 * `best_ckpt.pt`  -->  model checkpoint
 * `best.json`  -->  train/val/test metrics for the best model
 * `config.json`  -->  training configuration
-* `log.json`  -->  metrics for all tested models (in case of hyperparameter optimization:)
+* `log.json`  -->  metrics for all tested models (hyperparameter optimization)
 
 Below is an example `best.json` file, which contains info about the **metrics**, **timings**, and **hyperparameters**.
 
@@ -42,14 +35,12 @@ Below is an example `best.json` file, which contains info about the **metrics**,
             "forces_MAE": 15.919811367988586,
             "energy_RMSE": 0.31621758133552114,
             "forces_RMSE": 20.368873955871486,
-            "forces_cosim": 0.9990022741258144
         },
         "validation": {
             "energy_MAE": 0.23749234564490368,
             "forces_MAE": 16.388884401321413,
             "energy_RMSE": 0.31755570717758935,
             "forces_RMSE": 20.917586551063245,
-            "forces_cosim": 0.9989026814699173
         }
     },
     "hyperparameters": {

--- a/franken/autotune/cli.py
+++ b/franken/autotune/cli.py
@@ -16,6 +16,7 @@ from franken.config import (
     DatasetConfig,
     HPSearchConfig,
     DEFAULT_AUTOTUNE_METRICS,
+    DEFAULT_BEST_MODEL_SELECTION,
 )
 
 
@@ -512,6 +513,12 @@ def build_parser(return_groups: bool = False):
         help=get_field_docstring(AutotuneConfig, "metrics"),
     )
     parser.add_argument(
+        "--best-model-selection",
+        nargs="+",
+        default=DEFAULT_BEST_MODEL_SELECTION.copy(),
+        help=get_field_docstring(AutotuneConfig, "best_model_selection"),
+    )
+    parser.add_argument(
         "--global-scaling",
         action="store_true",
         default=False,
@@ -582,6 +589,7 @@ def parse_cli(argv):
         dtype=args.dtype,
         save_fmaps=args.save_fmaps,
         metrics=args.metrics,
+        best_model_selection=args.best_model_selection,
         scale_by_species=not args.global_scaling,
         jac_chunk_size=args.jac_chunk_size,
         run_dir=args.run_dir,

--- a/franken/autotune/script.py
+++ b/franken/autotune/script.py
@@ -15,11 +15,12 @@ from franken.autotune.cli import build_parser, parse_cli
 from franken.config import (
     AutotuneConfig,
     BackboneConfig,
+    DEFAULT_AUTOTUNE_METRICS,
+    DEFAULT_BEST_MODEL_SELECTION,
     HPSearchConfig,
     RFConfig,
     SolverConfig,
     asdict_with_classvar,
-    DEFAULT_AUTOTUNE_METRICS,
 )
 from franken.datasets.registry import DATASET_REGISTRY
 from franken.trainers.rf_cuda_lowmem import RandomFeaturesTrainer
@@ -151,9 +152,18 @@ def run_autotune(
     jac_chunk_size: int | Literal["auto"],
     trainer: BaseTrainer,
     metrics: list[str] | None = None,
+    best_model_selection: list[str] | None = None,
 ):
     if metrics is None:
         metrics = DEFAULT_AUTOTUNE_METRICS.copy()
+    if best_model_selection is None:
+        best_model_selection = DEFAULT_BEST_MODEL_SELECTION.copy()
+
+    for metric in best_model_selection:
+        if metric not in metrics:
+            raise ValueError(
+                f"best_model_selection metric '{metric}' is not present in computed metrics {metrics}"
+            )
 
     current_best = BestTrial(None, None)
     rf_param_grid = create_rf_hpsearch_grid(rf_cfg)
@@ -185,7 +195,13 @@ def run_autotune(
         )
         if dist_utils.get_rank() == 0:
             if trainer.log_dir is not None:
-                trainer.serialize_logs(model, logs, weights, split_for_best_model)
+                trainer.serialize_logs(
+                    model,
+                    logs,
+                    weights,
+                    split_for_best_model,
+                    best_model_selection=best_model_selection,
+                )
         dist_utils.barrier()
 
         # current best model update
@@ -333,6 +349,7 @@ def autotune(cfg: AutotuneConfig):
             solver_cfg=cfg.solver,
             loaders=loaders,
             metrics=cfg.metrics,
+            best_model_selection=cfg.best_model_selection,
             scale_by_species=cfg.scale_by_species,
             jac_chunk_size=cfg.jac_chunk_size,
             trainer=trainer,

--- a/franken/autotune/script.py
+++ b/franken/autotune/script.py
@@ -93,12 +93,37 @@ def hp_summary_str(trial_id: int, current_best: BestTrial, rf_params: RFConfig) 
     for k, v in rf_params.to_ckpt().items():
         fmt_val = format(v, ".3f" if isinstance(v, float) else "")
         hp_summary += f" {k:^7}: {fmt_val:^7} |"
-    try:
-        energy_error = current_best.log.get_metric("energy_MAE", DataSplit.VALIDATION)
-        forces_error = current_best.log.get_metric("forces_MAE", DataSplit.VALIDATION)
-    except KeyError:
-        energy_error = current_best.log.get_metric("energy_MAE", DataSplit.TRAIN)
-        forces_error = current_best.log.get_metric("forces_MAE", DataSplit.TRAIN)
+
+    def _get_first_available_metric(
+        candidates: list[str],
+        splits: list[DataSplit],
+    ) -> float | None:
+        for split in splits:
+            for name in candidates:
+                try:
+                    return current_best.log.get_metric(name, split)
+                except KeyError:
+                    pass
+        return None
+
+    energy_error = _get_first_available_metric(
+        ["energy_MAE", "energy_RMSE"],
+        [DataSplit.VALIDATION, DataSplit.TRAIN],
+    )
+    forces_error = _get_first_available_metric(
+        [
+            "forces_MAE",
+            "forces_MAE_species_average",
+            "forces_RMSE",
+            "forces_RMSE_species_average",
+        ],
+        [DataSplit.VALIDATION, DataSplit.TRAIN],
+    )
+
+    if energy_error is None:
+        energy_error = float("nan")
+    if forces_error is None:
+        forces_error = float("nan")
 
     hp_summary += (
         f" Best trial {current_best.trial_id} (energy {energy_error:.2f} meV/atom - "

--- a/franken/autotune/script.py
+++ b/franken/autotune/script.py
@@ -184,7 +184,6 @@ def run_autotune(
     if best_model_selection is None:
         best_model_selection = DEFAULT_BEST_MODEL_SELECTION.copy()
 
-
     current_best = BestTrial(None, None)
     rf_param_grid = create_rf_hpsearch_grid(rf_cfg)
     solver_param_grid = create_solver_hpsearch_grid(solver_cfg)

--- a/franken/autotune/script.py
+++ b/franken/autotune/script.py
@@ -184,11 +184,6 @@ def run_autotune(
     if best_model_selection is None:
         best_model_selection = DEFAULT_BEST_MODEL_SELECTION.copy()
 
-    for metric in best_model_selection:
-        if metric not in metrics:
-            raise ValueError(
-                f"best_model_selection metric '{metric}' is not present in computed metrics {metrics}"
-            )
 
     current_best = BestTrial(None, None)
     rf_param_grid = create_rf_hpsearch_grid(rf_cfg)

--- a/franken/config.py
+++ b/franken/config.py
@@ -328,6 +328,11 @@ DEFAULT_AUTOTUNE_METRICS = [
     "forces_cosim",
 ]
 
+DEFAULT_BEST_MODEL_SELECTION = [
+    "energy_MAE",
+    "forces_MAE",
+]
+
 
 @dataclass
 class AutotuneConfig:
@@ -379,6 +384,11 @@ class AutotuneConfig:
 
     metrics: list[str] = field(default_factory=lambda: DEFAULT_AUTOTUNE_METRICS.copy())
     """Metrics to compute during evaluation. Options: `energy_MAE`, `forces_MAE`, `energy_RMSE`, `forces_RMSE`, `forces_MAE_species`, `forces_RMSE_species`, `forces_cosim`. """
+
+    best_model_selection: list[str] = field(
+        default_factory=lambda: DEFAULT_BEST_MODEL_SELECTION.copy()
+    )
+    """Metrics used to select the best model among trials. This does not affect the training loss."""
 
     scale_by_species: bool = True
     """how to scale the GNN features, whether globally (across species) or individually per species."""

--- a/franken/trainers/base.py
+++ b/franken/trainers/base.py
@@ -7,7 +7,7 @@ from typing import Tuple, Union
 import torch
 import torch.utils.data
 
-from franken.config import asdict_with_classvar
+from franken.config import DEFAULT_BEST_MODEL_SELECTION, asdict_with_classvar
 from franken.rf.model import FrankenPotential
 from franken.rf.scaler import Statistics, compute_dataset_statistics
 from franken.trainers.log_utils import (
@@ -132,6 +132,7 @@ class BaseTrainer(abc.ABC):
         log_collection: LogCollection,
         all_weights: torch.Tensor,
         best_model_split: DataSplit = DataSplit.TRAIN,
+        best_model_selection: list[str] | None = None,
     ):
         assert self.log_dir is not None, "Log directory is not set"
         model_hash_set = set(log.checkpoint_hash for log in log_collection)
@@ -149,17 +150,27 @@ class BaseTrainer(abc.ABC):
                 f"Saved multiple models (hash={model_hash}) " f"to {model_save_path}"
             )
         # Log the best model
-        self.serialize_best_model(model, all_weights, split=best_model_split)
+        self.serialize_best_model(
+            model,
+            all_weights,
+            split=best_model_split,
+            best_model_selection=best_model_selection,
+        )
 
     def serialize_best_model(
         self,
         model: FrankenPotential,
         all_weights: torch.Tensor,
         split: DataSplit = DataSplit.TRAIN,
+        best_model_selection: list[str] | None = None,
     ) -> None:
         assert self.log_dir is not None, "Log directory is not set"
+        if best_model_selection is None:
+            best_model_selection = DEFAULT_BEST_MODEL_SELECTION.copy()
         log_collection = LogCollection.from_json(self.log_dir / "log.json")
-        best_model = log_collection.get_best_model(split=split)
+        best_model = log_collection.get_best_model(
+            split=split, metrics_to_minimize=best_model_selection
+        )
 
         best_model_file = self.log_dir / "best.json"
         should_save = True

--- a/franken/trainers/log_utils.py
+++ b/franken/trainers/log_utils.py
@@ -11,6 +11,7 @@ import torch
 
 import franken.metrics
 import franken.utils.distributed as dist_utils
+from franken.config import DEFAULT_BEST_MODEL_SELECTION
 
 
 logger = logging.getLogger("franken")
@@ -279,7 +280,7 @@ class LogCollection:
 
     def get_best_model(
         self,
-        metrics_to_minimize: list[str] = ["energy_MAE", "forces_MAE"],
+        metrics_to_minimize: list[str] | None = None,
         p: int = 1,
         split: DataSplit = DataSplit.TRAIN,
     ) -> LogEntry:
@@ -289,9 +290,30 @@ class LogCollection:
         by minimizing their ``p``-norm.
         The function returns a dictionary with information about the best model.
         """
-        available_metrics = franken.metrics.available_metrics()
+
+        if metrics_to_minimize is None:
+            metrics_to_minimize = DEFAULT_BEST_MODEL_SELECTION.copy()
+        if len(metrics_to_minimize) == 0:
+            raise ValueError("`metrics_to_minimize` (in best_model_selection) must contain at least one metric.")
+
+        available_metrics = {
+            metric.name
+            for entry in self.logs
+            for metric in entry.metrics
+            if metric.split == split
+        }
+
         for metric in metrics_to_minimize:
-            assert metric in available_metrics, f"Unknown {metric=}"
+            if metric.endswith("_species") and metric not in available_metrics:
+                raise ValueError(
+                    f"Metric '{metric}' is species-resolved and cannot be minimized directly. "
+                    f"Use '{metric}_average' for the species average, or one of the per-species "
+                    f"metrics like '{metric}_<Z>'."
+                )
+            assert (
+                metric in available_metrics
+            ), f"Unknown {metric=} for split={split}. Available: {sorted(available_metrics)}"
+
         costs = np.stack(
             [self.get_metric(m, split=split) for m in metrics_to_minimize], axis=-1
         )

--- a/franken/trainers/log_utils.py
+++ b/franken/trainers/log_utils.py
@@ -294,7 +294,9 @@ class LogCollection:
         if metrics_to_minimize is None:
             metrics_to_minimize = DEFAULT_BEST_MODEL_SELECTION.copy()
         if len(metrics_to_minimize) == 0:
-            raise ValueError("`metrics_to_minimize` (in best_model_selection) must contain at least one metric.")
+            raise ValueError(
+                "`metrics_to_minimize` (in best_model_selection) must contain at least one metric."
+            )
 
         available_metrics = {
             metric.name


### PR DESCRIPTION
Expose the metrics which are used to select the best model in autotune

Summary:
- add best_model_selection to AutotuneConfig
- expose it in CLI via --best-model-selection
- thread selection metrics through run_autotune and trainer serialization
- use selection metrics when choosing best.json and best_ckpt.pt
- add metrics page to documentation