### PR TITLE
Torch-sim integration

### DIFF
--- a/.github/env-dev.yml
+++ b/.github/env-dev.yml
@@ -21,5 +21,4 @@ dependencies:
 - metatrain
 - docstring_parser
 - packaging
-- torch-sim-atomistic
 name: franken

--- a/.github/env-dev.yml
+++ b/.github/env-dev.yml
@@ -21,4 +21,5 @@ dependencies:
 - metatrain
 - docstring_parser
 - packaging
+- torch-sim-atomistic
 name: franken

--- a/.github/env-docs.yml
+++ b/.github/env-docs.yml
@@ -29,5 +29,4 @@ dependencies:
 - myst-parser
 - nbsphinx
 - packaging
-- torch-sim-atomistic
 name: franken

--- a/.github/env-docs.yml
+++ b/.github/env-docs.yml
@@ -29,4 +29,5 @@ dependencies:
 - myst-parser
 - nbsphinx
 - packaging
+- torch-sim-atomistic
 name: franken

--- a/.github/req-dev.txt
+++ b/.github/req-dev.txt
@@ -1,0 +1,1 @@
+torch-sim-atomistic

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,11 +22,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.12", "3.13"]
         pytorch-version: ["2.10"]
-        exclude:
-          - python-version: "3.10"  # only to save CI minutes
-            pytorch-version: "2.10"
+        # exclude:
+        #   - python-version: "3.12"  # only to save CI minutes
+        #     pytorch-version: "2.10"
 
     steps:
       - uses: actions/checkout@v4
@@ -53,9 +53,15 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}
             pytorch=${{ matrix.pytorch-version }}
-
-      - name: Install GNN backbones packages
+      - name: Cache pip packages
+        id: cache-pip
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.pytorch-version }}-${{ hashFiles('.github/req-dev.txt') }}
+      - name: Install missing packages with pip
         # conda setup requires this special shell
+        if: steps.cache.outputs.cache-hit != 'true'
         shell: bash -l {0}
         env:
           TORCH_VERSION: ${{ matrix.pytorch-version }}
@@ -66,12 +72,13 @@ jobs:
           python -m pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.0+cpu.html
           python -m pip install --no-deps fairchem-core==1.10  # fairchem dependencies are a nightmare, better to ignore them
           python -m pip install mace-torch
+          python -m pip install --requirement .github/req-dev.txt  # installs torch-sim
 
       - name: Install package
         # conda setup requires this special shell
         shell: bash -l {0}
         run: |
-          python -m pip install . --no-deps
+          python -m pip install --no-deps --no-cache-dir .
           micromamba list
 
       - name: Run tests

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ Advantages of Franken
    topics/metrics.md
    topics/multigpu.md
    topics/lammps.md
+   topics/torchsim.md
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -13,8 +13,8 @@ Franken CLI Reference
      - Automatic hyperparameter tuning for franken models.
    * - :doc:`franken.calculators <franken-cli/franken.backbones>`
      - List and download GNN backbones for franken.
-   * - :doc:`franken.rf.model <franken-cli/franken.create_lammps_model>`
-     - Convert a franken model to be able to use it with LAMMPS.
+   * - :doc:`franken wrappers <franken-cli/franken.create_lammps_model>`
+     - Export inference wrappers for LAMMPS and other external runtimes.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/reference/franken-api/franken.calculators.rst
+++ b/docs/reference/franken-api/franken.calculators.rst
@@ -7,5 +7,7 @@
     :template: class.rst
     :nosignatures:
 
-        franken.calculators.FrankenCalculator
-        franken.calculators.LammpsFrankenCalculator
+    franken.calculators.FrankenCalculator
+    franken.calculators.MaceInferenceWrapper
+    franken.calculators.MetatomicInferenceWrapper
+    franken.calculators.FrankenTorchSimModel

--- a/docs/reference/franken-api/franken.config.rst
+++ b/docs/reference/franken-api/franken.config.rst
@@ -11,10 +11,11 @@ Backbone configuration
     :template: class.rst
     :nosignatures:
 
-        franken.config.MaceBackboneConfig
-        franken.config.FairchemBackboneConfig
-        franken.config.SevennBackboneConfig
-        franken.config.PetBackboneConfig
+    franken.config.BackboneConfig
+    franken.config.MaceBackboneConfig
+    franken.config.FairchemBackboneConfig
+    franken.config.SevennBackboneConfig
+    franken.config.PETBackboneConfig
 
 
 Random feature configuration
@@ -25,8 +26,9 @@ Random feature configuration
     :template: class.rst
     :nosignatures:
 
-        franken.config.GaussianRFConfig
-        franken.config.MultiscaleGaussianRFConfig
+    franken.config.RFConfig
+    franken.config.GaussianRFConfig
+    franken.config.MultiscaleGaussianRFConfig
 
 
 Other configurations
@@ -37,6 +39,7 @@ Other configurations
     :template: class.rst
     :nosignatures:
 
-        franken.config.DatasetConfig
-        franken.config.SolverConfig
-        franken.config.AutotuneConfig
+    franken.config.HPSearchConfig
+    franken.config.DatasetConfig
+    franken.config.SolverConfig
+    franken.config.AutotuneConfig

--- a/docs/reference/franken-cli/franken.create_lammps_model.rst
+++ b/docs/reference/franken-cli/franken.create_lammps_model.rst
@@ -4,7 +4,8 @@ Franken Inference Wrappers
 A learned `franken` model can be used directly for simple MD simulations via the :meth:`~franken.calculators.ase_calc.FrankenCalculator` calculator
 based on `ASE <https://ase-lib.org/>`_.
 To run more complex simulations, for example with `LAMMPS <https://www.lammps.org/>`_, we first need to export the model.
-This will both
+This will both:
+
  - speed up calculations since exported models are usually JIT compiled,
  - allow to call the model from external programs such as LAMMPS.
 

--- a/docs/topics/torchsim.md
+++ b/docs/topics/torchsim.md
@@ -1,0 +1,107 @@
+# Using Franken with torch-sim
+
+This page shows how to use `FrankenPotential` through the torch-sim interface.
+
+## What is supported
+- Backbones: `mace`, `pet`
+- Outputs: `energy`, `forces`
+- Stress/virials: not supported in this interface
+
+## Load
+
+### Load from checkpoint
+`FrankenTorchSimModel` can be initialized directly from a Franken checkpoint path (simplest option).
+
+```python
+import torch
+import torch_sim as ts
+
+from franken.calculators import FrankenTorchSimModel
+
+model = FrankenTorchSimModel(
+    "path/to/best_ckpt.pt",
+    device="cuda" if torch.cuda.is_available() else "cpu",
+    dtype=torch.float32,
+    rf_weight_id=None,  # set this when loading a multi-head checkpoint
+)
+```
+
+### Load from an already-instantiated Franken model
+```python
+import torch
+
+from franken.calculators import FrankenTorchSimModel
+from franken.rf.model import FrankenPotential
+
+franken = FrankenPotential.load("path/to/best_ckpt.pt", map_location="cuda")
+model = FrankenTorchSimModel(franken, device="cuda", dtype=torch.float32)
+```
+
+## Run a forward pass on a batched state
+The interface accepts a torch-sim `SimState` and returns a dictionary with:
+- `"energy"`: shape `[n_systems]`
+- `"forces"`: shape `[n_atoms, 3]`
+
+```python
+import torch
+import torch_sim as ts
+from ase.build import molecule
+
+from franken.calculators.torchsim_inf_wrap import FrankenTorchSimModel
+
+h2o = molecule("H2O")
+h2o.center(vacuum=5.0)
+ch4 = molecule("CH4")
+ch4.center(vacuum=5.0)
+
+state = ts.io.atoms_to_state(
+    [h2o, ch4],
+    device=torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+    dtype=torch.float32,
+)
+
+model = FrankenTorchSimModel("path/to/best_ckpt.pt", device=state.device, dtype=state.dtype)
+out = model(state)
+
+energy = out["energy"]  # [n_systems]
+forces = out["forces"]  # [n_atoms, 3]
+```
+
+## Run batched MD with `torch_sim.integrate`
+This example runs multiple systems in parallel using one batched integration call.
+
+```python
+import torch
+import torch_sim as ts
+from ase.io import read
+
+from franken.calculators import FrankenTorchSimModel
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+# model
+mace_model = FrankenTorchSimModel(
+    "path/to/best_ckpt.pt",
+    device=device,
+    dtype=torch.float32,
+)
+
+# system batch (same structure replicated)
+atoms = read("init_structure.xyz")
+batch_size = 16
+many_atoms = [atoms.copy() for _ in range(batch_size)]
+trajectory_files = [f"traj_{i}.h5md" for i in range(batch_size)]
+
+# batched MD
+final_state = ts.integrate(
+    system=many_atoms,
+    model=mace_model,
+    n_steps=nsteps,
+    timestep=0.001,
+    temperature=100,
+    integrator=ts.Integrator.nvt_langevin,
+    trajectory_reporter=dict(filenames=trajectory_files, state_frequency=10),
+)
+final_atoms_list = final_state.to_atoms()
+```
+

--- a/docs/topics/torchsim.md
+++ b/docs/topics/torchsim.md
@@ -1,11 +1,16 @@
 # Using Franken with torch-sim
 
-This page shows how to use `FrankenPotential` through the torch-sim interface.
+This page shows how to use `FrankenPotential` through the [torch-sim](https://github.com/TorchSim/torch-sim) interface.
 
 ## What is supported
 - Backbones: `mace`, `pet`
 - Outputs: `energy`, `forces`
 - Stress/virials: not supported in this interface
+
+## Installation gotchas
+
+ - torch-sim does not publish packages on conda-forge - installation must be with pip via `pip install torch-sim-atomistic`.
+ - torch-sim requires **at least python 3.12**
 
 ## Load
 
@@ -22,7 +27,7 @@ model = FrankenTorchSimModel(
     "path/to/best_ckpt.pt",
     device="cuda" if torch.cuda.is_available() else "cpu",
     dtype=torch.float32,
-    rf_weight_id=None,  # set this when loading a multi-head checkpoint
+    rf_weight_id=None,  # set this when loading a multi-head checkpoint (uncommon)
 )
 ```
 

--- a/franken/backbones/wrappers/mace_wrap.py
+++ b/franken/backbones/wrappers/mace_wrap.py
@@ -228,6 +228,7 @@ class FrankenMACE(torch.nn.Module):
         edge_index = data.edge_index
         assert edge_index is not None
         edge_index = edge_index.T  # mace expects [2, n_edges]
+        batch_ids = data.batch_ids
 
         shifts = data.shifts
         if shifts is None:
@@ -235,7 +236,15 @@ class FrankenMACE(torch.nn.Module):
             cell = data.cell
             assert unit_shifts is not None
             assert cell is not None
-            shifts = unit_shifts.to(cell.dtype) @ cell  # n_edges, 3
+            if cell.ndim == 2:
+                shifts = unit_shifts.to(cell.dtype) @ cell  # n_edges, 3
+            else:
+                assert batch_ids is not None
+                shifts = torch.einsum(
+                    "ni,nij->nj",
+                    unit_shifts.to(cell.dtype),
+                    cell[batch_ids[edge_index[0]]],
+                )
         assert shifts is not None
 
         node_attrs = data.node_attrs

--- a/franken/backbones/wrappers/pet_wrap.py
+++ b/franken/backbones/wrappers/pet_wrap.py
@@ -21,13 +21,15 @@ def systems_to_batch(
     positions: torch.Tensor,
     edge_index: torch.Tensor,
     cell: torch.Tensor,
-    cell_shifts: torch.Tensor,
+    unit_shifts: torch.Tensor,
     species: torch.Tensor,
     options: metatomic.torch.NeighborListOptions,
     species_to_species_index: torch.Tensor,
     cutoff_function: str,
     cutoff_width: float,
     num_neighbors_adaptive: Optional[float] = None,
+    cartesian_shifts: torch.Tensor | None = None,
+    edge_system_idx: torch.Tensor | None = None,
 ) -> Tuple[
     torch.Tensor,
     torch.Tensor,
@@ -43,38 +45,25 @@ def systems_to_batch(
         and are not used for feature computation. 2. input is taken as a config, and no concatenation is needed.
     Converts a list of systems to a batch required for the PET model.
 
-    :param systems: List of systems to convert to a batch.
-    :param options: Options for the neighbor list.
-    :param all_species_list: List of all atomic species in the dataset.
-    :param species_to_species_index: Mapping from atomic species to species indices.
-    :param cutoff_function: Type of the smoothing function at the cutoff.
-    :param cutoff_width: Width of the cutoff function for a cutoff mask.
-    :param num_neighbors_adaptive: Optional maximum number of neighbors per atom.
-        If provided, the adaptive cutoff scheme will be used for each atom to
-        approximately select this number of neighbors.
-    :return: A tuple containing the batch tensors.
-        The batch consists of the following tensors:
-        - `element_indices_nodes`: The atomic species of the central atoms
-        - `element_indices_neighbors`: The atomic species of the neighboring atoms
-        - `edge_vectors`: The cartesian edge vectors between the central atoms and their
-            neighbors
-        - `edge_distances`: The distances between the central atoms and their neighbors
-        - `padding_mask`: A padding mask indicating which neighbors are real, and which
-            are padded
-        - `reverse_neighbor_index`: The reversed neighbor list for each central atom
-        - `cutoff_factors`: The cutoff function values for each edge
-        - `system_indices`: The system index for each atom in the batch
-        - `sample_labels`: Labels indicating the system and atom indices for each atom
-
+    `unit_shifts` must contain integer cell shifts and is used to reconstruct
+    corresponding edge pairs. If `cartesian_shifts` is provided, it is used
+    directly for edge-vector computation.
     """
     centers = edge_index[:, 0]
     neighbors = edge_index[:, 1]
-    cells = cell.unsqueeze(0)  # Franken: unsqueeze needed to 'fake' multiple systems
 
-    # somehow the backward of this operation is very slow at evaluation,
-    # where there is only one cell, therefore we simplify the calculation
-    # for that case
-    cell_contributions = cell_shifts.to(cells.dtype) @ cells[0]
+    if cartesian_shifts is None:
+        if cell.ndim == 2:
+            cell_contributions = unit_shifts.to(cell.dtype) @ cell
+        else:
+            assert edge_system_idx is not None
+            edge_cells = cell[edge_system_idx]
+            cell_contributions = torch.einsum(
+                "ni,nij->nj", unit_shifts.to(edge_cells.dtype), edge_cells
+            )
+    else:
+        cell_contributions = cartesian_shifts.to(dtype=positions.dtype)
+
     edge_vectors = positions[neighbors] - positions[centers] + cell_contributions
     edge_distances = torch.norm(edge_vectors, dim=-1) + 1e-15
 
@@ -103,7 +92,7 @@ def systems_to_batch(
             centers = centers[cutoff_mask]
             neighbors = neighbors[cutoff_mask]
             edge_vectors = edge_vectors[cutoff_mask]
-            cell_shifts = cell_shifts[cutoff_mask]
+            unit_shifts = unit_shifts[cutoff_mask]
             edge_distances = edge_distances[cutoff_mask]
     else:
         pair_cutoffs = options.cutoff * torch.ones(
@@ -115,10 +104,6 @@ def systems_to_batch(
     max_edges_per_node = (
         int(torch.max(num_neighbors)) if num_neighbors.numel() > 0 else 0
     )
-
-    # uncomment these to print out stats on the adaptive cutoff behavior
-    # print("adaptive_cutoffs", *pair_cutoffs.tolist())
-    # print("num_neighbors", *num_neighbors.tolist())
 
     if cutoff_function.lower() == "bump":
         # use bump switching function for adaptive cutoff
@@ -151,7 +136,7 @@ def systems_to_batch(
 
     corresponding_edges = get_corresponding_edges(
         torch.concatenate(
-            [centers.unsqueeze(-1), neighbors.unsqueeze(-1), cell_shifts],
+            [centers.unsqueeze(-1), neighbors.unsqueeze(-1), unit_shifts],
             dim=-1,
         )
     )
@@ -227,10 +212,22 @@ class PETModelWrapper(torch.nn.Module):
         # Make torch jit script happy by having everything in local variables
         edge_index = data.edge_index
         cell = data.cell
-        cell_shifts = data.unit_shifts
-        assert cell_shifts is not None
+        unit_shifts = data.unit_shifts
+        cartesian_shifts = data.shifts
+        assert unit_shifts is not None
         assert edge_index is not None
         assert cell is not None
+
+        batch_ids = data.batch_ids
+        edge_system_idx: torch.Tensor | None = None
+        if cell.ndim == 3:
+            if batch_ids is None:
+                edge_system_idx = torch.zeros(
+                    edge_index.shape[0], dtype=torch.long, device=edge_index.device
+                )
+            else:
+                edge_system_idx = batch_ids.to(dtype=torch.long)[edge_index[:, 0]]
+
         species = data.atomic_numbers
         # **Stage 0: Input Preparation**
         (
@@ -245,13 +242,15 @@ class PETModelWrapper(torch.nn.Module):
             data.atom_pos,
             edge_index,
             cell,
-            cell_shifts,
+            unit_shifts,
             species,
             nl_options,
             self.base_model.species_to_species_index,  # pyright: ignore[reportArgumentType]
             self.base_model.cutoff_function,
             self.base_model.cutoff_width,
             self.base_model.num_neighbors_adaptive,
+            cartesian_shifts=cartesian_shifts,
+            edge_system_idx=edge_system_idx,
         )
         # Franken: use_manual_attention switches FlashAttention off. It is required for forward autograd!
         # **Stage 1: Feature Computation via GNN Layers**

--- a/franken/backbones/wrappers/pet_wrap.py
+++ b/franken/backbones/wrappers/pet_wrap.py
@@ -27,9 +27,9 @@ def systems_to_batch(
     species_to_species_index: torch.Tensor,
     cutoff_function: str,
     cutoff_width: float,
+    batch_ids: torch.Tensor,
     num_neighbors_adaptive: Optional[float] = None,
     cartesian_shifts: torch.Tensor | None = None,
-    edge_system_idx: torch.Tensor | None = None,
 ) -> Tuple[
     torch.Tensor,
     torch.Tensor,
@@ -56,10 +56,8 @@ def systems_to_batch(
         if cell.ndim == 2:
             cell_contributions = unit_shifts.to(cell.dtype) @ cell
         else:
-            assert edge_system_idx is not None
-            edge_cells = cell[edge_system_idx]
             cell_contributions = torch.einsum(
-                "ni,nij->nj", unit_shifts.to(edge_cells.dtype), edge_cells
+                "ni,nij->nj", unit_shifts.to(positions.dtype), cell[batch_ids[centers]]
             )
     else:
         cell_contributions = cartesian_shifts.to(dtype=positions.dtype)
@@ -219,14 +217,11 @@ class PETModelWrapper(torch.nn.Module):
         assert cell is not None
 
         batch_ids = data.batch_ids
-        edge_system_idx: torch.Tensor | None = None
-        if cell.ndim == 3:
-            if batch_ids is None:
-                edge_system_idx = torch.zeros(
-                    edge_index.shape[0], dtype=torch.long, device=edge_index.device
-                )
-            else:
-                edge_system_idx = batch_ids.to(dtype=torch.long)[edge_index[:, 0]]
+        if batch_ids is None:
+            # single system
+            batch_ids = torch.zeros(
+                data.atom_pos.shape[0], dtype=torch.int, device=data.atom_pos.device
+            )
 
         species = data.atomic_numbers
         # **Stage 0: Input Preparation**
@@ -248,9 +243,9 @@ class PETModelWrapper(torch.nn.Module):
             self.base_model.species_to_species_index,  # pyright: ignore[reportArgumentType]
             self.base_model.cutoff_function,
             self.base_model.cutoff_width,
-            self.base_model.num_neighbors_adaptive,
+            batch_ids=batch_ids,
+            num_neighbors_adaptive=self.base_model.num_neighbors_adaptive,
             cartesian_shifts=cartesian_shifts,
-            edge_system_idx=edge_system_idx,
         )
         # Franken: use_manual_attention switches FlashAttention off. It is required for forward autograd!
         # **Stage 1: Feature Computation via GNN Layers**

--- a/franken/calculators/__init__.py
+++ b/franken/calculators/__init__.py
@@ -7,9 +7,11 @@ extended to support your favorite MD software.
 from .ase_calc import FrankenCalculator
 from .mace_inf_wrap import MaceInferenceWrapper
 from .metatomic_inf_wrap import MetatomicInferenceWrapper
+from .torchsim_inf_wrap import FrankenTorchSimModel
 
 __all__ = (
     "FrankenCalculator",
     "MaceInferenceWrapper",
     "MetatomicInferenceWrapper",
+    "FrankenTorchSimModel",
 )

--- a/franken/calculators/mace_inf_wrap.py
+++ b/franken/calculators/mace_inf_wrap.py
@@ -90,6 +90,7 @@ class MaceInferenceWrapper(torch.nn.Module):
         assert forces is not None
         # Kokkos doesn't like total_energy_local and only looks at node_energy.
         # We hack around this:
+        energy = energy.squeeze()  # [M, N] -> [1]
         node_energy = energy.repeat(len(atom_nums)).div(len(atom_nums))
         virials: Optional[torch.Tensor] = None
         if compute_virials:

--- a/franken/calculators/metatomic_inf_wrap.py
+++ b/franken/calculators/metatomic_inf_wrap.py
@@ -25,6 +25,78 @@ class MetatomicInferenceWrapper(torch.nn.Module):
         self.model = franken_model
         self.model.gnn.franken_val()
 
+    def concatenate_structures(
+        self,
+        systems: List[System],
+    ) -> tuple[Configuration, torch.Tensor]:
+        """
+        Concatenate a list of systems into a single batch.
+
+        :param systems: List of systems to concatenate.
+        :param neighbor_list_options: Options for the neighbor list.
+        :return: A tuple containing the concatenated positions, centers, neighbors,
+            species, cells, cell shifts, system indices, and sample labels.
+        """
+
+        positions: List[torch.Tensor] = []
+        centers: List[torch.Tensor] = []
+        neighbors: List[torch.Tensor] = []
+        species: List[torch.Tensor] = []
+        cell_shifts: List[torch.Tensor] = []
+        shifts: List[torch.Tensor] = []
+        cells: List[torch.Tensor] = []
+        system_indices: List[torch.Tensor] = []
+        atom_indices: List[torch.Tensor] = []
+        pbcs: List[torch.Tensor] = []
+        node_counter = 0
+
+        for i, system in enumerate(systems):
+            known_neighbor_lists = system.known_neighbor_lists()
+            if len(known_neighbor_lists) != 1:
+                raise NotImplementedError(
+                    f"Requested {len(known_neighbor_lists)} neighbor lists. We only support 1."
+                )
+            neighbor_list = system.get_neighbor_list(known_neighbor_lists[0])
+            nl_values = neighbor_list.samples.values
+
+            centers_values = nl_values[:, 0]
+            neighbors_values = nl_values[:, 1]
+            cell_shifts_values = nl_values[:, 2:]
+
+            system_size = len(system)
+            positions.append(system.positions)
+            species.append(system.types)
+            pbcs.append(system.pbc)
+
+            centers.append(centers_values + node_counter)
+            neighbors.append(neighbors_values + node_counter)
+            cell_shifts.append(cell_shifts_values)
+            cells.append(system.cell)
+            shifts.append(cell_shifts_values.to(system.cell.dtype) @ system.cell)
+
+            node_counter += system_size
+            system_indices.append(
+                torch.full((system_size,), i, device=system.positions.device)
+            )
+            atom_indices.append(
+                torch.arange(system_size, device=system.positions.device)
+            )
+
+        batch_ids = torch.cat(system_indices)
+        return Configuration(
+            atom_pos=torch.cat(positions),
+            edge_index=torch.stack([torch.cat(centers), torch.cat(neighbors)], dim=1),
+            natoms=torch.bincount(batch_ids, minlength=len(systems)).to(
+                dtype=torch.int64
+            ),
+            atomic_numbers=torch.cat(species),
+            cell=torch.stack(cells, dim=0),
+            unit_shifts=torch.cat(cell_shifts),
+            shifts=torch.cat(shifts),
+            batch_ids=batch_ids,
+            pbc=torch.stack(pbcs),
+        ), torch.cat(atom_indices)
+
     def forward(
         self,
         systems: List[System],
@@ -37,62 +109,22 @@ class MetatomicInferenceWrapper(torch.nn.Module):
                 f"keys: {', '.join(outputs.keys())}"
             )
 
-        # Build sample labels.
-        #  This was originally part of `concatenate_structures` in PET code
-        system_indices_lst: List[torch.Tensor] = []
-        atom_indices_lst: List[torch.Tensor] = []
-        for i, system in enumerate(systems):
-            system_size = len(system)
-            system_indices_lst.append(
-                torch.full((system_size,), i, device=system.positions.device)
-            )
-            atom_indices_lst.append(
-                torch.arange(system_size, device=system.positions.device)
-            )
-        system_indices = torch.cat(system_indices_lst)
-        atom_indices = torch.cat(atom_indices_lst)
-        sample_values = torch.stack([system_indices, atom_indices], dim=1)
-        sample_labels = Labels(
-            names=["system", "atom"],
-            values=sample_values,
-        )
-
-        # Compute energy with underlying model
         device = systems[0].positions.device
-        energy_lst: List[torch.Tensor] = []
-        for i, system in enumerate(systems):
-            known_neighbor_lists = system.known_neighbor_lists()
-            if len(known_neighbor_lists) != 1:
-                raise NotImplementedError(
-                    f"Requested {len(known_neighbor_lists)} neighbor lists. We only support 1."
-                )
-            neighbor_list = system.get_neighbor_list(known_neighbor_lists[0])
-            nl_values = neighbor_list.samples.values
-            franken_data = Configuration(
-                atom_pos=system.positions,
-                atomic_numbers=system.types,
-                natoms=torch.tensor(
-                    len(system.types), dtype=torch.int32, device=device
-                ).view(1),
-                pbc=system.pbc,
-                cell=system.cell,
-                unit_shifts=nl_values[:, 2:],
-                edge_index=nl_values[:, :2],
-            )
-            # Don't compute_forces. This will be done in the metatomic calculator.
-            # in theory we could set the `explicit_gradients` capability in the model
-            # but it doesn't seem to be actually used anywhere in the calculators (which
-            # rely on performing autograd themselves)
-            sys_energy, _ = self.model(franken_data, compute_forces=False)
-            # Fake per-atom energy. Needed for LAMMPS calculator
-            node_energy = sys_energy.repeat(system.positions.shape[0]).div(
-                system.positions.shape[0]
-            )
-            energy_lst.append(node_energy)
-        # Concatenate energy from all systems.
-        energy = torch.cat(energy_lst, 0)
+        # Concatenate systems into a single Configuration object
+        concat_data, atom_indices = self.concatenate_structures(systems)
+        batch_ids = concat_data.batch_ids
+        assert batch_ids is not None
+        # Compute energy with underlying model. This is per-system energy
+        energy = self.model.energy(None, concat_data)  # [M, N]
+        # Convert it to per-atom energy
+        energy = energy / concat_data.natoms[None, ...]  # [M, N]
+        energy = torch.gather(energy, dim=1, index=batch_ids[None, ...])  # [M, A]
 
         # Build the weird output format required by metatomic
+        # 1. Build sample labels
+        sample_values = torch.stack([batch_ids, atom_indices], dim=1)
+        sample_labels = Labels(names=["system", "atom"], values=sample_values)
+        # 2. Energy block
         energy_block = TensorBlock(
             values=energy.reshape(-1, 1),
             samples=sample_labels,

--- a/franken/calculators/torchsim_inf_wrap.py
+++ b/franken/calculators/torchsim_inf_wrap.py
@@ -28,7 +28,6 @@ except ImportError:
             raise
 
 else:
-
     class FrankenTorchSimModel(ModelInterface):  # type: ignore
         """Wrap a FrankenPotential model with the torch-sim ``ModelInterface`` API.
 
@@ -83,7 +82,7 @@ else:
 
         def forward(
             self,
-            state: torch_sim.state.SimState | torch_sim.typing.StateDict,
+            state: torch_sim.state.SimState | torch_sim.typing.StateLike,
             **_kwargs: Any,
         ) -> dict[str, torch.Tensor]:
             """Compute energies and forces for one or more systems."""

--- a/franken/calculators/torchsim_inf_wrap.py
+++ b/franken/calculators/torchsim_inf_wrap.py
@@ -1,9 +1,7 @@
-"""torch-sim interface for FrankenPotential."""
-
 from pathlib import Path
 import traceback
-import warnings
 from typing import Any, Callable
+import warnings
 
 import torch
 
@@ -13,35 +11,31 @@ from franken.rf.model import FrankenPotential
 
 
 try:
-    import torch_sim as ts
+    import torch_sim.state
+    import torch_sim.typing
+    import torch_sim.transforms
     from torch_sim.models.interface import ModelInterface
     from torch_sim.neighbors import torchsim_nl
-except ImportError as exc:
+except ImportError:
     warnings.warn(
         f"torch-sim import failed: {traceback.format_exc()}",
         stacklevel=2,
     )
-
-    class FrankenTorchSimModel(torch.nn.Module):
-        """Placeholder class when torch-sim is not installed."""
-
-        def __init__(self, err: ImportError = exc, *_args: Any, **_kwargs: Any) -> None:
-            raise err
-
+    ModelInterface = object
 else:
 
     class FrankenTorchSimModel(ModelInterface):
         """Wrap a FrankenPotential model with the torch-sim ``ModelInterface`` API.
 
         This adapter returns per-system energies and per-atom forces. Stress is not
-        supported in this first version.
+        supported.
         """
 
         def __init__(
             self,
             franken_model: FrankenPotential | str | Path,
             *,
-            device: torch.device | str | None = None,
+            device: torch.device | str,
             dtype: torch.dtype = torch.float32,
             rf_weight_id: int | None = None,
             neighbor_list_fn: Callable = torchsim_nl,
@@ -55,17 +49,10 @@ else:
                     "FrankenTorchSimModel does not support stress in this version."
                 )
 
-            resolved_device: torch.device
-            if device is None:
-                resolved_device = torch.device(
-                    "cuda" if torch.cuda.is_available() else "cpu"
-                )
-            elif isinstance(device, str):
-                resolved_device = torch.device(device)
+            if isinstance(device, str):
+                self._device = torch.device(device)
             else:
-                resolved_device = device
-
-            self._device = resolved_device
+                self._device = device
             self._dtype = dtype
             self._compute_forces = compute_forces
             self._compute_stress = False
@@ -85,11 +72,6 @@ else:
                     "franken_model must be a FrankenPotential instance or a checkpoint path"
                 )
 
-            family = getattr(self.model.gnn_config, "family", None)
-            if family not in ("mace", "pet"):
-                raise NotImplementedError(
-                    f"FrankenTorchSimModel supports only MACE/PET backbones, found {family!r}."
-                )
             if not isinstance(self.model.gnn, AtomisticModelWrapper):
                 raise NotImplementedError(
                     "Underlying Franken backbone does not implement AtomisticModelWrapper."
@@ -99,34 +81,33 @@ else:
             self.model.gnn.franken_val()
 
         def forward(
-            self, state: ts.SimState, **_kwargs: Any
+            self,
+            state: torch_sim.state.SimState | torch_sim.typing.StateDict,
+            **_kwargs: Any,
         ) -> dict[str, torch.Tensor]:
             """Compute energies and forces for one or more systems."""
-            sim_state = state
+
+            sim_state = (
+                state
+                if isinstance(state, torch_sim.state.SimState)
+                else torch_sim.state.SimState(
+                    **state, masses=torch.ones_like(state["positions"])
+                )
+            )
+
             if sim_state.device != self._device or sim_state.dtype != self._dtype:
                 sim_state = sim_state.to(device=self._device, dtype=self._dtype)
 
-            system_idx = sim_state.system_idx.to(dtype=torch.long)
-            pbc = sim_state.pbc
-            pbc_batched = (
-                pbc.unsqueeze(0).expand(sim_state.n_systems, -1)
-                if pbc.ndim == 1
-                else pbc
-            )
-
+            # Wrap positions into the unit cell
             wrapped_positions = (
-                (
-                    ts.transforms.pbc_wrap_batched(
-                        sim_state.positions,
-                        sim_state.cell,
-                        system_idx,
-                        pbc,
-                    )
-                    if pbc.any()
-                    else sim_state.positions
+                torch_sim.transforms.pbc_wrap_batched(
+                    sim_state.positions,
+                    sim_state.cell,
+                    sim_state.system_idx,
+                    sim_state.pbc,
                 )
-                .detach()
-                .clone()
+                if sim_state.pbc.any()
+                else sim_state.positions
             )
 
             cutoff = torch.tensor(
@@ -134,42 +115,41 @@ else:
                 dtype=self._dtype,
                 device=self._device,
             )
+            # Batched neighbor list using linked-cell algorithm
             edge_index, mapping_system, unit_shifts = self.neighbor_list_fn(
                 positions=wrapped_positions,
                 cell=sim_state.row_vector_cell,
-                pbc=pbc_batched,
+                pbc=sim_state.pbc,
                 cutoff=cutoff,
-                system_idx=system_idx,
+                system_idx=sim_state.system_idx,
             )
-
-            shifts = ts.transforms.compute_cell_shifts(
-                sim_state.row_vector_cell,
-                unit_shifts,
-                mapping_system,
+            # Convert unit cell shift indices to Cartesian shifts
+            shifts = torch_sim.transforms.compute_cell_shifts(
+                sim_state.row_vector_cell, unit_shifts, mapping_system
             )
 
             data = Configuration(
                 atom_pos=wrapped_positions,
                 atomic_numbers=sim_state.atomic_numbers,
-                natoms=torch.bincount(system_idx, minlength=sim_state.n_systems).to(
-                    dtype=torch.int64
-                ),
+                natoms=torch.bincount(
+                    sim_state.system_idx, minlength=sim_state.n_systems
+                ).long(),
                 edge_index=edge_index.transpose(0, 1),
                 shifts=shifts,
                 unit_shifts=unit_shifts,
                 cell=sim_state.row_vector_cell,
-                batch_ids=system_idx,
+                batch_ids=sim_state.system_idx,
                 pbc=sim_state.pbc,
             )
 
-            energy, forces = self.model.energy_and_forces_batched(
+            energy, forces = self.model(
                 data,
                 compute_forces=self._compute_forces,
                 add_energy_shift=True,
             )
 
-            results: dict[str, torch.Tensor] = {"energy": energy.detach()}
+            results: dict[str, torch.Tensor] = {"energy": energy.detach().squeeze(0)}
             if self._compute_forces:
                 assert forces is not None
-                results["forces"] = forces.detach()
+                results["forces"] = forces.detach().squeeze(0)
             return results

--- a/franken/calculators/torchsim_inf_wrap.py
+++ b/franken/calculators/torchsim_inf_wrap.py
@@ -28,6 +28,7 @@ except ImportError:
             raise
 
 else:
+
     class FrankenTorchSimModel(ModelInterface):  # type: ignore
         """Wrap a FrankenPotential model with the torch-sim ``ModelInterface`` API.
 

--- a/franken/calculators/torchsim_inf_wrap.py
+++ b/franken/calculators/torchsim_inf_wrap.py
@@ -98,7 +98,9 @@ else:
             self.model = self.model.to(device=self._device, dtype=self._dtype).eval()
             self.model.gnn.franken_val()
 
-        def forward(self, state: ts.SimState, **_kwargs: Any) -> dict[str, torch.Tensor]:
+        def forward(
+            self, state: ts.SimState, **_kwargs: Any
+        ) -> dict[str, torch.Tensor]:
             """Compute energies and forces for one or more systems."""
             sim_state = state
             if sim_state.device != self._device or sim_state.dtype != self._dtype:
@@ -113,15 +115,19 @@ else:
             )
 
             wrapped_positions = (
-                ts.transforms.pbc_wrap_batched(
-                    sim_state.positions,
-                    sim_state.cell,
-                    system_idx,
-                    pbc,
+                (
+                    ts.transforms.pbc_wrap_batched(
+                        sim_state.positions,
+                        sim_state.cell,
+                        system_idx,
+                        pbc,
+                    )
+                    if pbc.any()
+                    else sim_state.positions
                 )
-                if pbc.any()
-                else sim_state.positions
-            ).detach().clone()
+                .detach()
+                .clone()
+            )
 
             cutoff = torch.tensor(
                 self.model.gnn.cutoff_radius(),

--- a/franken/calculators/torchsim_inf_wrap.py
+++ b/franken/calculators/torchsim_inf_wrap.py
@@ -21,10 +21,15 @@ except ImportError:
         f"torch-sim import failed: {traceback.format_exc()}",
         stacklevel=2,
     )
-    ModelInterface = object
+
+    class FrankenTorchSimModel:
+        # dummy class in case imports failed
+        def __init__(self):
+            raise
+
 else:
 
-    class FrankenTorchSimModel(ModelInterface):
+    class FrankenTorchSimModel(ModelInterface):  # type: ignore
         """Wrap a FrankenPotential model with the torch-sim ``ModelInterface`` API.
 
         This adapter returns per-system energies and per-atom forces. Stress is not

--- a/franken/calculators/torchsim_inf_wrap.py
+++ b/franken/calculators/torchsim_inf_wrap.py
@@ -1,0 +1,169 @@
+"""torch-sim interface for FrankenPotential."""
+
+from pathlib import Path
+import traceback
+import warnings
+from typing import Any, Callable
+
+import torch
+
+from franken.backbones.wrappers.base import AtomisticModelWrapper
+from franken.data.base import Configuration
+from franken.rf.model import FrankenPotential
+
+
+try:
+    import torch_sim as ts
+    from torch_sim.models.interface import ModelInterface
+    from torch_sim.neighbors import torchsim_nl
+except ImportError as exc:
+    warnings.warn(
+        f"torch-sim import failed: {traceback.format_exc()}",
+        stacklevel=2,
+    )
+
+    class FrankenTorchSimModel(torch.nn.Module):
+        """Placeholder class when torch-sim is not installed."""
+
+        def __init__(self, err: ImportError = exc, *_args: Any, **_kwargs: Any) -> None:
+            raise err
+
+else:
+
+    class FrankenTorchSimModel(ModelInterface):
+        """Wrap a FrankenPotential model with the torch-sim ``ModelInterface`` API.
+
+        This adapter returns per-system energies and per-atom forces. Stress is not
+        supported in this first version.
+        """
+
+        def __init__(
+            self,
+            franken_model: FrankenPotential | str | Path,
+            *,
+            device: torch.device | str | None = None,
+            dtype: torch.dtype = torch.float32,
+            rf_weight_id: int | None = None,
+            neighbor_list_fn: Callable = torchsim_nl,
+            compute_forces: bool = True,
+            compute_stress: bool = False,
+        ) -> None:
+            super().__init__()
+
+            if compute_stress:
+                raise NotImplementedError(
+                    "FrankenTorchSimModel does not support stress in this version."
+                )
+
+            resolved_device: torch.device
+            if device is None:
+                resolved_device = torch.device(
+                    "cuda" if torch.cuda.is_available() else "cpu"
+                )
+            elif isinstance(device, str):
+                resolved_device = torch.device(device)
+            else:
+                resolved_device = device
+
+            self._device = resolved_device
+            self._dtype = dtype
+            self._compute_forces = compute_forces
+            self._compute_stress = False
+            self._memory_scales_with = "n_atoms_x_density"
+            self.neighbor_list_fn = neighbor_list_fn
+
+            if isinstance(franken_model, FrankenPotential):
+                self.model = franken_model
+            elif isinstance(franken_model, (str, Path)):
+                self.model = FrankenPotential.load(
+                    franken_model,
+                    map_location=self._device,
+                    rf_weight_id=rf_weight_id,
+                )
+            else:
+                raise TypeError(
+                    "franken_model must be a FrankenPotential instance or a checkpoint path"
+                )
+
+            family = getattr(self.model.gnn_config, "family", None)
+            if family not in ("mace", "pet"):
+                raise NotImplementedError(
+                    f"FrankenTorchSimModel supports only MACE/PET backbones, found {family!r}."
+                )
+            if not isinstance(self.model.gnn, AtomisticModelWrapper):
+                raise NotImplementedError(
+                    "Underlying Franken backbone does not implement AtomisticModelWrapper."
+                )
+
+            self.model = self.model.to(device=self._device, dtype=self._dtype).eval()
+            self.model.gnn.franken_val()
+
+        def forward(self, state: ts.SimState, **_kwargs: Any) -> dict[str, torch.Tensor]:
+            """Compute energies and forces for one or more systems."""
+            sim_state = state
+            if sim_state.device != self._device or sim_state.dtype != self._dtype:
+                sim_state = sim_state.to(device=self._device, dtype=self._dtype)
+
+            system_idx = sim_state.system_idx.to(dtype=torch.long)
+            pbc = sim_state.pbc
+            pbc_batched = (
+                pbc.unsqueeze(0).expand(sim_state.n_systems, -1)
+                if pbc.ndim == 1
+                else pbc
+            )
+
+            wrapped_positions = (
+                ts.transforms.pbc_wrap_batched(
+                    sim_state.positions,
+                    sim_state.cell,
+                    system_idx,
+                    pbc,
+                )
+                if pbc.any()
+                else sim_state.positions
+            ).detach().clone()
+
+            cutoff = torch.tensor(
+                self.model.gnn.cutoff_radius(),
+                dtype=self._dtype,
+                device=self._device,
+            )
+            edge_index, mapping_system, unit_shifts = self.neighbor_list_fn(
+                positions=wrapped_positions,
+                cell=sim_state.row_vector_cell,
+                pbc=pbc_batched,
+                cutoff=cutoff,
+                system_idx=system_idx,
+            )
+
+            shifts = ts.transforms.compute_cell_shifts(
+                sim_state.row_vector_cell,
+                unit_shifts,
+                mapping_system,
+            )
+
+            data = Configuration(
+                atom_pos=wrapped_positions,
+                atomic_numbers=sim_state.atomic_numbers,
+                natoms=torch.bincount(system_idx, minlength=sim_state.n_systems).to(
+                    dtype=torch.int64
+                ),
+                edge_index=edge_index.transpose(0, 1),
+                shifts=shifts,
+                unit_shifts=unit_shifts,
+                cell=sim_state.row_vector_cell,
+                batch_ids=system_idx,
+                pbc=sim_state.pbc,
+            )
+
+            energy, forces = self.model.energy_and_forces_batched(
+                data,
+                compute_forces=self._compute_forces,
+                add_energy_shift=True,
+            )
+
+            results: dict[str, torch.Tensor] = {"energy": energy.detach()}
+            if self._compute_forces:
+                assert forces is not None
+                results["forces"] = forces.detach()
+            return results

--- a/franken/calculators/torchsim_inf_wrap.py
+++ b/franken/calculators/torchsim_inf_wrap.py
@@ -64,22 +64,18 @@ else:
             self._memory_scales_with = "n_atoms_x_density"
             self.neighbor_list_fn = neighbor_list_fn
 
-            if isinstance(franken_model, FrankenPotential):
-                self.model = franken_model
-            elif isinstance(franken_model, (str, Path)):
+            if isinstance(franken_model, (str, Path)):
                 self.model = FrankenPotential.load(
                     franken_model,
                     map_location=self._device,
                     rf_weight_id=rf_weight_id,
                 )
             else:
-                raise TypeError(
-                    "franken_model must be a FrankenPotential instance or a checkpoint path"
-                )
+                self.model = franken_model
 
             if not isinstance(self.model.gnn, AtomisticModelWrapper):
                 raise NotImplementedError(
-                    "Underlying Franken backbone does not implement AtomisticModelWrapper."
+                    f"Underlying Franken backbone does not implement AtomisticModelWrapper. Found type {type(self.model.gnn)}"
                 )
 
             self.model = self.model.to(device=self._device, dtype=self._dtype).eval()

--- a/franken/config.py
+++ b/franken/config.py
@@ -390,7 +390,12 @@ class AutotuneConfig:
     """Whether to save training feature maps. If the dataset is small (~100 samples), setting this to True can increase the speed of hyperparameter tuning, at the cost of higher memory usage."""
 
     metrics: list[str] = field(default_factory=lambda: DEFAULT_AUTOTUNE_METRICS.copy())
-    """Metrics to compute during evaluation. Options: `energy_MAE`, `forces_MAE`, `energy_RMSE`, `forces_RMSE`, `forces_MAE_species`, `forces_RMSE_species`, `forces_cosim`. """
+    """Metrics to compute during evaluation.
+
+    Options include ``energy_MAE``, ``forces_MAE``, ``energy_RMSE``,
+    ``forces_RMSE``, ``forces_MAE_species``, ``forces_RMSE_species``,
+    and ``forces_cosim``.
+    """
 
     best_model_selection: list[str] = field(
         default_factory=lambda: DEFAULT_BEST_MODEL_SELECTION.copy()

--- a/franken/data/base.py
+++ b/franken/data/base.py
@@ -3,7 +3,7 @@ import dataclasses
 import logging
 import sys
 from pathlib import Path
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch.utils.data
@@ -94,6 +94,69 @@ class Configuration:
             pbc=pbc,
         )
 
+    @staticmethod
+    def concatenate(configs: Sequence["Configuration"]) -> "Configuration":
+        positions: list[torch.Tensor] = []
+        edge_indices: list[Tensor] = []
+        species: list[torch.Tensor] = []
+        unit_shifts: list[torch.Tensor] = []
+        shifts: list[torch.Tensor] = []
+        cells: list[torch.Tensor] = []
+        all_batch_ids: list[torch.Tensor] = []
+        pbcs: list[torch.Tensor] = []
+        node_counter = 0
+
+        # Check that all are consistent
+        pbc_none = np.asarray([c.pbc is None for c in configs])
+        if not np.all(pbc_none == pbc_none[0]):
+            raise ValueError("PBC inconsistent")
+        edge_index_none = np.asarray([c.edge_index is None for c in configs])
+        if not np.all(edge_index_none == edge_index_none[0]):
+            raise ValueError("Edge index inconsistent")
+        shifts_none = np.asarray([c.shifts is None for c in configs])
+        if not np.all(shifts_none == shifts_none[0]):
+            raise ValueError("Shifts inconsistent")
+        unit_shifts_none = np.asarray([c.unit_shifts is None for c in configs])
+        if not np.all(unit_shifts_none == unit_shifts_none[0]):
+            raise ValueError("Unit shifts inconsistent")
+        cell_none = np.asarray([c.cell is None for c in configs])
+        if not np.all(cell_none == cell_none[0]):
+            raise ValueError("Cell inconsistent")
+
+        for i, config in enumerate(configs):
+            system_size = len(config.atom_pos)
+            positions.append(config.atom_pos)
+            species.append(config.atomic_numbers)
+            if config.pbc is not None:
+                pbcs.append(config.pbc)
+            if config.edge_index is not None:
+                edge_indices.append(config.edge_index + node_counter)
+            if config.unit_shifts is not None:
+                unit_shifts.append(config.unit_shifts)
+            if config.cell is not None:
+                cells.append(config.cell)
+            if config.shifts is not None:
+                shifts.append(config.shifts)
+            all_batch_ids.append(
+                torch.full((system_size,), i, device=config.atom_pos.device)
+            )
+            node_counter += system_size
+
+        batch_ids = torch.cat(all_batch_ids)
+        return Configuration(
+            atom_pos=torch.cat(positions),
+            edge_index=torch.cat(edge_indices) if len(edge_indices) > 0 else None,
+            natoms=torch.bincount(batch_ids, minlength=len(configs)).to(
+                dtype=torch.int64
+            ),
+            atomic_numbers=torch.cat(species),
+            cell=torch.stack(cells, dim=0) if len(cells) > 0 else None,
+            unit_shifts=torch.cat(unit_shifts) if len(unit_shifts) > 0 else None,
+            shifts=torch.cat(shifts) if len(shifts) > 0 else None,
+            batch_ids=batch_ids,
+            pbc=torch.stack(pbcs) if len(pbcs) > 0 else None,
+        )
+
 
 @dataclasses.dataclass
 class Target:
@@ -111,6 +174,32 @@ class Target:
                 else None
             ),
         )
+
+    def detach(self) -> "Target":
+        return Target(
+            energy=self.energy.detach(),
+            forces=self.forces.detach() if self.forces is not None else None,
+        )
+
+    # @staticmethod
+    # def concatenate(targets: Sequence['Target']):
+    #     energies: list[Tensor] = []
+    #     forcess: list[Tensor] = []
+
+    #     forces_none = np.asarray([t.forces is None for t in targets])
+    #     if not np.all(forces_none == forces_none[0]):
+    #         raise ValueError("Forces inconsistent")
+
+    #     for target in targets:
+    #         energies.append(target.energy)
+    #         if target.forces is not None:
+    #             forcess.append(target.forces)
+
+    #     return Configuration(
+    #         atom_pos=torch.cat(positions),
+    #         edge_index=torch.cat(edge_indices) if len(edge_indices) > 0 else None,
+
+    #     torch.cat([prd1.energy, prd2.energy], dim=1), torch.cat([prd1.forces, prd2.forces], dim=1)
 
 
 class BaseAtomsDataset(torch.utils.data.Dataset, abc.ABC):

--- a/franken/data/base.py
+++ b/franken/data/base.py
@@ -103,10 +103,10 @@ class Configuration:
         shifts: list[torch.Tensor] = []
         cells: list[torch.Tensor] = []
         all_batch_ids: list[torch.Tensor] = []
-        pbcs: list[torch.Tensor] = []
+        pbc: torch.Tensor | None = None
         node_counter = 0
 
-        # Check that all are consistent
+        # Check that all are consistently None or not None
         pbc_none = np.asarray([c.pbc is None for c in configs])
         if not np.all(pbc_none == pbc_none[0]):
             raise ValueError("PBC inconsistent")
@@ -127,8 +127,12 @@ class Configuration:
             system_size = len(config.atom_pos)
             positions.append(config.atom_pos)
             species.append(config.atomic_numbers)
+            # All PBCs must be equal across configs! They will not be stacked.
             if config.pbc is not None:
-                pbcs.append(config.pbc)
+                if pbc is None:
+                    pbc = config.pbc
+                else:
+                    assert torch.all(pbc == config.pbc)
             if config.edge_index is not None:
                 edge_indices.append(config.edge_index + node_counter)
             if config.unit_shifts is not None:
@@ -154,7 +158,7 @@ class Configuration:
             unit_shifts=torch.cat(unit_shifts) if len(unit_shifts) > 0 else None,
             shifts=torch.cat(shifts) if len(shifts) > 0 else None,
             batch_ids=batch_ids,
-            pbc=torch.stack(pbcs) if len(pbcs) > 0 else None,
+            pbc=pbc,
         )
 
 

--- a/franken/metrics/base.py
+++ b/franken/metrics/base.py
@@ -12,7 +12,6 @@ class BaseMetric:
         device: torch.device,
         dtype: torch.dtype = torch.float64,
         units: Mapping[str, str | None] = {},
-        requires_species: bool = False,
     ):
         self.name = name
         self.device = device
@@ -20,7 +19,6 @@ class BaseMetric:
         self.buffer = None
         self.samples_counter = torch.zeros((1,), device=device, dtype=dtype)
         self.units = units
-        self.requires_species = requires_species
 
     def reset(self) -> None:
         """Reset the buffer to zeros"""

--- a/franken/metrics/base.py
+++ b/franken/metrics/base.py
@@ -2,7 +2,7 @@ from typing import Mapping
 import torch
 
 import franken.utils.distributed as dist_utils
-from franken.data.base import Target
+from franken.data.base import Configuration, Target
 
 
 class BaseMetric:
@@ -35,11 +35,7 @@ class BaseMetric:
         self.buffer += value
         self.samples_counter += num_samples
 
-    def update(
-        self,
-        predictions: Target,
-        targets: Target,
-    ) -> None:
+    def update(self, predictions: Target, targets: Target, data: Configuration) -> None:
         """Update the metric buffer with new batch results"""
         raise NotImplementedError()
 

--- a/franken/metrics/functions.py
+++ b/franken/metrics/functions.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
 
-from franken.data.base import Target
+from franken.data.base import Configuration, Target
 from franken.metrics.base import BaseMetric
 from franken.metrics.registry import registry
 from franken.utils import distributed
@@ -19,6 +19,42 @@ __all__ = [
 ]
 
 
+def add_batch_dim(t: torch.Tensor, expected_dims: int) -> torch.Tensor:
+    if t.ndim == expected_dims:
+        return t
+    if t.ndim == expected_dims - 1:
+        return t[None, ...]
+    raise ValueError(
+        f"Tensor has too few dimensions. Expected at least {expected_dims - 1} but found {t.ndim}"
+    )
+
+
+def check_energy_sizes(pred: Target, tgt: Target):
+    # energy. preds: [n_models, n_configs], targets: [n_configs]
+    e_pred = add_batch_dim(pred.energy, 2)
+    e_tgt = torch.atleast_1d(tgt.energy)
+    if e_tgt.ndim != 1:
+        raise ValueError(f"Energy target has invalid shape {e_tgt.shape}")
+    n_models, n_configs = e_pred.shape
+    if e_tgt.shape[0] != n_configs:
+        raise ValueError(
+            f"Energy target has invalid shape {e_tgt.shape} because predictions have shape {e_pred.shape}"
+        )
+    return e_pred, e_tgt
+
+
+def check_force_sizes(pred: Target, tgt: Target):
+    if tgt.forces is None or pred.forces is None:
+        raise AttributeError(
+            "Forces must be specified to compute a force-based metric."
+        )
+    f_pred = add_batch_dim(pred.forces, 3)
+    f_tgt = tgt.forces
+    if f_tgt.ndim != 2:
+        raise ValueError(f"Energy target has invalid shape {f_tgt.shape}")
+    return f_pred, f_tgt
+
+
 class EnergyMAE(BaseMetric):
     def __init__(self, device: torch.device, dtype: torch.dtype = torch.float32):
         units = {
@@ -27,19 +63,14 @@ class EnergyMAE(BaseMetric):
         }
         super().__init__("energy_MAE", device, dtype, units)
 
-    def update(self, predictions: Target, targets: Target) -> None:
-        if targets.forces is None:
-            raise NotImplementedError(
-                "At the moment, target's forces are required to get the number of atoms in the configuration."
-            )
-        num_atoms = targets.forces.shape[-2]
-        num_samples = 1
-        if targets.energy.ndim > 0:
-            num_samples = targets.energy.shape[0]
+    def update(self, predictions: Target, targets: Target, data: Configuration) -> None:
+        num_atoms = torch.atleast_1d(data.natoms)
+        # energy. preds: [n_models, n_configs], targets: [n_configs]
+        e_pred, e_tgt = check_energy_sizes(predictions, targets)
 
-        error = 1000 * torch.abs(targets.energy - predictions.energy) / num_atoms
+        error = (1000 * torch.abs(e_tgt[None, :] - e_pred) / num_atoms[None, :]).sum(1)
 
-        self.buffer_add(error, num_samples=num_samples)
+        self.buffer_add(error, num_samples=e_tgt.shape[0])
 
 
 class EnergyRMSE(BaseMetric):
@@ -50,19 +81,14 @@ class EnergyRMSE(BaseMetric):
         }
         super().__init__("energy_RMSE", device, dtype, units)
 
-    def update(self, predictions: Target, targets: Target) -> None:
-        if targets.forces is None:
-            raise NotImplementedError(
-                "At the moment, target's forces are required to get the number of atoms in the configuration."
-            )
-        num_atoms = targets.forces.shape[-2]
-        num_samples = 1
-        if targets.energy.ndim > 0:
-            num_samples = targets.energy.shape[0]
+    def update(self, predictions: Target, targets: Target, data: Configuration) -> None:
+        num_atoms = torch.atleast_1d(data.natoms)
+        # energy. preds: [n_models, n_configs], targets: [n_configs]
+        e_pred, e_tgt = check_energy_sizes(predictions, targets)
 
-        error = torch.square((targets.energy - predictions.energy) / num_atoms)
+        error = torch.square((e_tgt[None, :] - e_pred) / num_atoms[None, :]).sum(1)
 
-        self.buffer_add(error, num_samples=num_samples)
+        self.buffer_add(error, num_samples=e_tgt.shape[0])
 
     def compute(self, reset: bool = True) -> torch.Tensor:
         if self.buffer is None:
@@ -88,19 +114,14 @@ class ForcesMAE(BaseMetric):
         }
         super().__init__("forces_MAE", device, dtype, units)
 
-    def update(self, predictions: Target, targets: Target) -> None:
-        if targets.forces is None or predictions.forces is None:
-            raise AttributeError("Forces must be specified to compute the MAE.")
-        num_samples = 1
-        if targets.forces.ndim > 2:
-            num_samples = targets.forces.shape[0]
-        elif targets.forces.ndim < 2:
-            raise ValueError("Forces must be a 2D tensor or a batch of 2D tensors.")
+    def update(self, predictions: Target, targets: Target, data: Configuration) -> None:
+        # forces (predicted): [n_models, n_atoms, 3]  (target): [n_atoms, 3]
+        f_pred, f_tgt = check_force_sizes(predictions, targets)
 
-        error = 1000 * torch.abs(targets.forces - predictions.forces)
+        error = 1000 * torch.abs(f_tgt[None, ...] - f_pred)
         error = error.mean(dim=(-1, -2))  # Average over atoms and components
 
-        self.buffer_add(error, num_samples=num_samples)
+        self.buffer_add(error, num_samples=1)
 
 
 class ForcesMAESpecies(BaseMetric):
@@ -132,37 +153,22 @@ class ForcesMAESpecies(BaseMetric):
             self.buffer.zero_()
         self.samples_counter.zero_()
 
-    def update(
-        self,
-        predictions: Target,
-        targets: Target,
-        atomic_numbers: torch.Tensor,
-    ) -> None:
-
-        # ---- assertions on species ----
+    def update(self, predictions: Target, targets: Target, data: Configuration) -> None:
+        # forces (predicted): [n_models, n_atoms, 3]  (target): [n_atoms, 3]
+        f_pred, f_tgt = check_force_sizes(predictions, targets)
+        atomic_numbers = data.atomic_numbers
         assert atomic_numbers.ndim == 1
-        assert atomic_numbers.shape[0] == targets.forces.shape[-2]
+        assert atomic_numbers.shape[0] == f_tgt.shape[-2]
         assert atomic_numbers.max() <= self.Z_MAX
 
-        if targets.forces is None or predictions.forces is None:
-            raise AttributeError("Forces must be specified to compute the MAE.")
         # |ΔF| in eV/Å, averaged over Cartesian components
-        # shapes:
-        #   single model: (N,)
-        #   ensemble:     (M, N)
-        error = torch.abs(targets.forces - predictions.forces).mean(dim=-1)
-        if error.ndim == 1:
-            error = error.unsqueeze(0)  # (1, N)
-
+        error = torch.abs(f_tgt[None, ...] - f_pred).mean(dim=-1)
         n_models = error.shape[0]
 
         # lazy buffer initialization
         if self.buffer is None:
             self.buffer = torch.zeros(
-                self.Z_MAX + 1,
-                n_models,
-                device=self.device,
-                dtype=self.dtype,
+                self.Z_MAX + 1, n_models, device=self.device, dtype=self.dtype
             )
 
         species = torch.unique(atomic_numbers)
@@ -243,28 +249,15 @@ class ForcesRMSESpecies(BaseMetric):
             self.buffer.zero_()
         self.samples_counter.zero_()
 
-    def update(
-        self,
-        predictions: Target,
-        targets: Target,
-        atomic_numbers: torch.Tensor,
-    ) -> None:
-
-        # ---- assertions on species ----
+    def update(self, predictions: Target, targets: Target, data: Configuration) -> None:
+        # forces (predicted): [n_models, n_atoms, 3]  (target): [n_atoms, 3]
+        f_pred, f_tgt = check_force_sizes(predictions, targets)
+        atomic_numbers = data.atomic_numbers
         assert atomic_numbers.ndim == 1
-        assert atomic_numbers.shape[0] == targets.forces.shape[-2]
+        assert atomic_numbers.shape[0] == f_tgt.shape[-2]
         assert atomic_numbers.max() <= self.Z_MAX
-
-        if targets.forces is None or predictions.forces is None:
-            raise AttributeError("Forces must be specified to compute the RMSE.")
         # ΔF^2 in (eV/Å)^2, averaged over Cartesian components
-        # shapes:
-        #   single model: (N,)
-        #   ensemble:     (M, N)
-        error = torch.square(targets.forces - predictions.forces).mean(dim=-1)
-        if error.ndim == 1:
-            error = error.unsqueeze(0)  # (1, N)
-
+        error = torch.square(f_tgt[None, ...] - f_pred).mean(dim=-1)
         n_models = error.shape[0]
 
         # lazy buffer initialization
@@ -333,19 +326,14 @@ class ForcesRMSE(BaseMetric):
         }
         super().__init__("forces_RMSE", device, dtype, units)
 
-    def update(self, predictions: Target, targets: Target) -> None:
-        if targets.forces is None or predictions.forces is None:
-            raise AttributeError("Forces must be specified to compute the MAE.")
-        num_samples = 1
-        if targets.forces.ndim > 2:
-            num_samples = targets.forces.shape[0]
-        elif targets.forces.ndim < 2:
-            raise ValueError("Forces must be a 2D tensor or a batch of 2D tensors.")
+    def update(self, predictions: Target, targets: Target, data: Configuration) -> None:
+        # forces (predicted): [n_models, n_atoms, 3]  (target): [n_atoms, 3]
+        f_pred, f_tgt = check_force_sizes(predictions, targets)
 
-        error = torch.square(targets.forces - predictions.forces)
+        error = torch.square(f_tgt[None, ...] - f_pred)
         error = error.mean(dim=(-1, -2))  # Average over atoms and components
 
-        self.buffer_add(error, num_samples=num_samples)
+        self.buffer_add(error, num_samples=1)
 
     def compute(self, reset: bool = True) -> torch.Tensor:
         if self.buffer is None:
@@ -373,19 +361,28 @@ class ForcesRMSE2(BaseMetric):
         }
         super().__init__("forces_RMSE", device, dtype, units)
 
-    def update(self, predictions: Target, targets: Target) -> None:
-        if targets.forces is None or predictions.forces is None:
-            raise AttributeError("Forces must be specified to compute the MAE.")
-        num_samples = 1
-        if targets.forces.ndim > 2:
-            num_samples = targets.forces.shape[0]
-        elif targets.forces.ndim < 2:
-            raise ValueError("Forces must be a 2D tensor or a batch of 2D tensors.")
+    def update(self, predictions: Target, targets: Target, data: Configuration) -> None:
+        # forces (predicted): [n_models, n_atoms, 3]  (target): [n_atoms, 3]
+        f_pred, f_tgt = check_force_sizes(predictions, targets)
+        n_models = f_pred.shape[0]
 
-        error = torch.square(targets.forces - predictions.forces)
-        error = error.mean(dim=(-1, -2))  # Average over atoms and components
-        error = torch.sqrt(error) * 1000
-        self.buffer_add(error, num_samples=num_samples)
+        # initial averaging over XYZ
+        error = torch.square(f_tgt[None, ...] - f_pred).mean(-1)  # [M, A]
+        if data.batch_ids is not None:
+            # Compute RMSE within each structure
+            n_configs = len(torch.atleast_1d(data.natoms))
+            batch_ids = data.batch_ids.unsqueeze(0).expand(n_models, -1)
+            error = torch.zeros(
+                (n_models, n_configs), device=self.device, dtype=self.dtype
+            ).scatter_reduce_(1, batch_ids, error, "mean", include_self=False)
+            error = torch.sqrt(error) * 1000
+            # Average over structures
+            error = error.mean(dim=-1)
+        else:
+            # Average over atoms in structure
+            error = error.mean(dim=-1)
+            error = torch.sqrt(error) * 1000
+        self.buffer_add(error, num_samples=1)
 
 
 class ForcesCosineSimilarity(BaseMetric):
@@ -396,24 +393,15 @@ class ForcesCosineSimilarity(BaseMetric):
         }
         super().__init__("forces_cosim", device, dtype, units)
 
-    def update(
-        self,
-        predictions: Target,
-        targets: Target,
-    ) -> None:
-        num_samples = 1
-        assert targets.forces is not None
-        assert predictions.forces is not None
-        if targets.forces.ndim > 2:
-            num_samples = targets.forces.shape[0]
-        elif targets.forces.ndim < 2:
-            raise ValueError("Forces must be a 2D tensor or a batch of 2D tensors.")
+    def update(self, predictions: Target, targets: Target, data: Configuration) -> None:
+        # forces (predicted): [n_models, n_atoms, 3]  (target): [n_atoms, 3]
+        f_pred, f_tgt = check_force_sizes(predictions, targets)
 
         cos_similarity = torch.nn.functional.cosine_similarity(
-            predictions.forces, targets.forces, dim=-1
+            f_pred, f_tgt[None, ...], dim=-1
         )
         cos_similarity = cos_similarity.mean(dim=-1)
-        self.buffer_add(cos_similarity, num_samples=num_samples)
+        self.buffer_add(cos_similarity, num_samples=1)
 
 
 def is_pareto_efficient(costs):

--- a/franken/metrics/functions.py
+++ b/franken/metrics/functions.py
@@ -141,7 +141,6 @@ class ForcesMAESpecies(BaseMetric):
             device=device,
             dtype=dtype,
             units=units,
-            requires_species=True,
         )
 
         # buffers will be initialized later once we know n_models
@@ -237,7 +236,6 @@ class ForcesRMSESpecies(BaseMetric):
             device=device,
             dtype=dtype,
             units=units,
-            requires_species=True,
         )
 
         # buffers will be initialized later once we know n_models

--- a/franken/rf/atomic_energies.py
+++ b/franken/rf/atomic_energies.py
@@ -51,25 +51,47 @@ class AtomicEnergiesShift(torch.nn.Module):
         )
         self.is_initialized = True
 
-    def forward(self, atomic_numbers: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        atomic_numbers: torch.Tensor,
+        batch_ids: torch.Tensor | None = None,
+        num_systems: int | None = None,
+    ) -> torch.Tensor:
         """
         Calculate the energy shift for a given set of atomic numbers.
 
         Args:
-            atomic_numbers: A tensor containing atomic numbers for which to calculate the energy shift.
+            atomic_numbers: Atomic numbers for all atoms.
+            batch_ids: Optional system index per atom. If provided, returns one
+                shift per system.
+            num_systems: Optional number of systems. If omitted, inferred from
+                ``batch_ids``.
 
         Returns:
-            A tensor representing the total energy shift for the provided atomic numbers.
+            Scalar shift for single-system inputs, or a tensor of shape
+            ``[n_systems]`` when ``batch_ids`` is provided.
         """
+        if batch_ids is None:
+            shift = torch.tensor(
+                0.0, dtype=self.atomic_energies.dtype, device=self.atomic_energies.device
+            )
+            for z, atom_ene in zip(self.z_keys, self.atomic_energies):
+                mask = atomic_numbers == int(z.item())
+                shift += torch.sum(atom_ene * mask)
+            return shift
 
-        shift = torch.tensor(
-            0.0, dtype=self.atomic_energies.dtype, device=self.atomic_energies.device
+        batch_ids = batch_ids.to(dtype=torch.long, device=atomic_numbers.device)
+        if num_systems is None:
+            num_systems = int(batch_ids.max().item()) + 1 if batch_ids.numel() > 0 else 0
+
+        shift = torch.zeros(
+            (num_systems,), dtype=self.atomic_energies.dtype, device=self.atomic_energies.device
         )
-
         for z, atom_ene in zip(self.z_keys, self.atomic_energies):
-            mask = atomic_numbers == z  # int(z.item())
-            shift += torch.sum(atom_ene * mask)
-
+            contrib = atom_ene * (atomic_numbers == z).to(
+                dtype=self.atomic_energies.dtype
+            )
+            shift = shift.index_add(0, batch_ids, contrib)
         return shift
 
     def __repr__(self):

--- a/franken/rf/atomic_energies.py
+++ b/franken/rf/atomic_energies.py
@@ -78,7 +78,7 @@ class AtomicEnergiesShift(torch.nn.Module):
                 device=self.atomic_energies.device,
             )
             for z, atom_ene in zip(self.z_keys, self.atomic_energies):
-                mask = atomic_numbers == int(z.item())
+                mask = atomic_numbers == z
                 shift += torch.sum(atom_ene * mask)
             return shift
 

--- a/franken/rf/atomic_energies.py
+++ b/franken/rf/atomic_energies.py
@@ -73,7 +73,9 @@ class AtomicEnergiesShift(torch.nn.Module):
         """
         if batch_ids is None:
             shift = torch.tensor(
-                0.0, dtype=self.atomic_energies.dtype, device=self.atomic_energies.device
+                0.0,
+                dtype=self.atomic_energies.dtype,
+                device=self.atomic_energies.device,
             )
             for z, atom_ene in zip(self.z_keys, self.atomic_energies):
                 mask = atomic_numbers == int(z.item())
@@ -82,10 +84,14 @@ class AtomicEnergiesShift(torch.nn.Module):
 
         batch_ids = batch_ids.to(dtype=torch.long, device=atomic_numbers.device)
         if num_systems is None:
-            num_systems = int(batch_ids.max().item()) + 1 if batch_ids.numel() > 0 else 0
+            num_systems = (
+                int(batch_ids.max().item()) + 1 if batch_ids.numel() > 0 else 0
+            )
 
         shift = torch.zeros(
-            (num_systems,), dtype=self.atomic_energies.dtype, device=self.atomic_energies.device
+            (num_systems,),
+            dtype=self.atomic_energies.dtype,
+            device=self.atomic_energies.device,
         )
         for z, atom_ene in zip(self.z_keys, self.atomic_energies):
             contrib = atom_ene * (atomic_numbers == z).to(

--- a/franken/rf/heads.py
+++ b/franken/rf/heads.py
@@ -334,7 +334,8 @@ class BiasedOrthogonalRFF(OrthogonalRFF):
 
 class MultiScaleOrthogonalRFF(RandomFeaturesHead):
     r"""
-    A multi-scale version of :class:`OrthogonalRFF` which splits the available random features among multiple length-scales.
+    A multi-scale version of :class:`franken.rf.heads.OrthogonalRFF` which splits
+    the available random features among multiple length-scales.
     This approximates a mixture of Gaussian kernels at different scales, simplifying hyper-parameter tuning.
 
     .. math::

--- a/franken/rf/heads.py
+++ b/franken/rf/heads.py
@@ -64,27 +64,27 @@ class RandomFeaturesHead(torch.nn.Module):
         self.register_buffer("weights", torch.zeros((1, self.total_random_features)))
 
     def species_scatter_sum(
-        self, Z: torch.Tensor, atomic_numbers: torch.Tensor | None = None
+        self,
+        Z: torch.Tensor,
+        atomic_numbers: torch.Tensor | None = None,
+        batch_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        r"""Average features across all atoms in a configuration.
+        r"""Average features across all atoms in one or more configurations.
 
         Depending on the configuration of random features, this function will either perform
         a simple average, or will use a chemically-informed averaging method where features
-        are averaged within each atomic type and concatenated across atomic types. In this latter
-        case, the number of output features is larger than the number of input features. It will
-        always be equal to :code:`self.total_random_features`.
+        are averaged within each atomic type and concatenated across atomic types.
 
-        Args:
-            Z (torch.Tensor): [num_atoms, feature_dim] tensor containing the random features for each atom
-            atomic_numbers (torch.Tensor | None): if specified, an integer tensor of size [num_atoms]
-                detailing the atomic number of each atom in the configuration. Defaults to None.
+        If ``batch_ids`` is ``None``, this behaves as before and returns a single
+        feature vector of shape ``[total_feature_dim]``.
 
-        Returns:
-            torch.Tensor: [total_feature_dim] tensor containing the random features for the whole configuration.
+        If ``batch_ids`` is specified, this computes a per-system feature map and
+        returns a tensor of shape ``[n_systems, total_feature_dim]``.
         """
-        if self.num_species is None:
-            return Z.mean(0)
-        else:
+        if batch_ids is None:
+            if self.num_species is None:
+                return Z.mean(0)
+
             assert (
                 atomic_numbers is not None
             ), "atomic_number should be specified when self.num_species is not None"
@@ -97,7 +97,7 @@ class RandomFeaturesHead(torch.nn.Module):
 
             scatter_idxs = scatter_idxs.unsqueeze(-1).expand(
                 Z.size()
-            )  # ~[natoms, random_features_per_species] Broadcasting for backprop.
+            )  # ~[natoms, random_features_per_species] Broadcasting for backprop.
             chemically_informed_descriptors = (
                 torch.zeros((self.num_species, self.num_random_features), dtype=Z.dtype)
                 .to(Z.device)
@@ -116,6 +116,57 @@ class RandomFeaturesHead(torch.nn.Module):
                     )
                 )
             return chemically_informed_descriptors.view(-1)
+
+        batch_ids = batch_ids.to(dtype=torch.long)
+        n_systems = int(batch_ids.max().item()) + 1 if batch_ids.numel() > 0 else 0
+
+        if self.num_species is None:
+            out = torch.zeros((n_systems, Z.shape[1]), dtype=Z.dtype, device=Z.device)
+            out = out.index_add(0, batch_ids, Z)
+            counts = torch.bincount(batch_ids, minlength=n_systems).to(dtype=Z.dtype)
+            return out / counts.clamp_min(1).unsqueeze(-1)
+
+        assert (
+            atomic_numbers is not None
+        ), "atomic_number should be specified when self.num_species is not None"
+        species_map, scatter_idxs = torch.unique(
+            atomic_numbers, sorted=True, return_inverse=True
+        )
+        assert (
+            len(species_map) == self.num_species
+        ), f"The provided atomic numbers {species_map}, are of a different number than self.num_species {self.num_species}"
+
+        flat_scatter = (batch_ids * self.num_species + scatter_idxs).to(torch.long)
+        n_bins = n_systems * self.num_species
+        out = torch.zeros((n_bins, Z.shape[1]), dtype=Z.dtype, device=Z.device)
+        out = out.index_add(0, flat_scatter, Z)
+        counts = torch.bincount(flat_scatter, minlength=n_bins).to(dtype=Z.dtype)
+        out = out / counts.clamp_min(1).unsqueeze(-1)
+        chemically_informed_descriptors = out.view(
+            n_systems, self.num_species, self.num_random_features
+        )
+        chemically_informed_descriptors = (
+            chemically_informed_descriptors / self.num_species
+        )  # Normalize.
+
+        if self.chemically_informed_ratio is not None:
+            kappa = self.chemically_informed_ratio
+            assert (
+                0 <= kappa <= 1
+            ), "The ratio of chemically informed feature feature map should be bounded between 0 and 1"
+            global_mean = torch.zeros((n_systems, Z.shape[1]), dtype=Z.dtype, device=Z.device)
+            global_mean = global_mean.index_add(0, batch_ids, Z)
+            global_counts = torch.bincount(batch_ids, minlength=n_systems).to(dtype=Z.dtype)
+            global_mean = global_mean / global_counts.clamp_min(1).unsqueeze(-1)
+            chemically_informed_descriptors = torch.cat(
+                (
+                    ((1 - kappa) * global_mean).unsqueeze(1),
+                    kappa * chemically_informed_descriptors,
+                ),
+                dim=1,
+            )
+
+        return chemically_informed_descriptors.view(n_systems, -1)
 
     def init_args(self):
         """Returns the arguments needed to re-initialize this class."""
@@ -231,6 +282,7 @@ class OrthogonalRFF(RandomFeaturesHead):
         self,
         h: torch.Tensor,
         atomic_numbers: torch.Tensor | None = None,
+        batch_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Computes the random-feature map for a given configuration :code:`h`
 
@@ -256,7 +308,7 @@ class OrthogonalRFF(RandomFeaturesHead):
             Z = torch.cat((_s, _c), dim=-1) / sqrt(self.num_random_features)
 
         return self.species_scatter_sum(
-            Z, atomic_numbers=atomic_numbers
+            Z, atomic_numbers=atomic_numbers, batch_ids=batch_ids
         )  # Sum over the single species
 
     def init_args(self):
@@ -294,12 +346,17 @@ class BiasedOrthogonalRFF(OrthogonalRFF):
         self,
         h: torch.Tensor,
         atomic_numbers: torch.Tensor | None = None,
+        batch_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
         self.bias = self.bias.to(dtype=h.dtype)
         # unbiased_features ~ [num_random_features - 1]
-        features = super().feature_map(h, atomic_numbers=atomic_numbers)
-        assert features.ndim == 1
-        features[-1] = torch.sqrt(self.bias)
+        features = super().feature_map(
+            h, atomic_numbers=atomic_numbers, batch_ids=batch_ids
+        )
+        if features.ndim == 1:
+            features[-1] = torch.sqrt(self.bias)
+        else:
+            features[:, -1] = torch.sqrt(self.bias)
         return features
 
     def init_args(self):
@@ -398,6 +455,7 @@ class MultiScaleOrthogonalRFF(RandomFeaturesHead):
         self,
         h: torch.Tensor,
         atomic_numbers: torch.Tensor | None = None,
+        batch_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Computes the random-feature map for a given configuration :code:`h`
 
@@ -425,7 +483,7 @@ class MultiScaleOrthogonalRFF(RandomFeaturesHead):
             Z = torch.cat((_s, _c), dim=-1) / sqrt(self.num_random_features)
 
         return self.species_scatter_sum(
-            Z, atomic_numbers=atomic_numbers
+            Z, atomic_numbers=atomic_numbers, batch_ids=batch_ids
         )  # Sum over the single species
 
     def init_args(self):
@@ -483,6 +541,7 @@ class Linear(RandomFeaturesHead):
         self,
         h: torch.Tensor,
         atomic_numbers: torch.Tensor | None = None,
+        batch_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Computes the random-feature map for a given configuration :code:`h`
 
@@ -503,7 +562,9 @@ class Linear(RandomFeaturesHead):
         scaled_descriptors = torch.cat([scaled_descriptors, bias_feature], dim=1)
 
         return self.species_scatter_sum(
-            scaled_descriptors, atomic_numbers=atomic_numbers
+            scaled_descriptors,
+            atomic_numbers=atomic_numbers,
+            batch_ids=batch_ids,
         )
 
     def init_args(self):
@@ -596,6 +657,7 @@ class TensorSketch(RandomFeaturesHead):
         self,
         h: torch.Tensor,
         atomic_numbers: torch.Tensor | None = None,
+        batch_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Computes the random-feature map for a given configuration :code:`h`
 
@@ -616,7 +678,11 @@ class TensorSketch(RandomFeaturesHead):
         Z = torch.fft.rfft(Z, n=self.num_random_features)
         Z = Z.prod(1)  # ~[atoms, random_features]
         Z = torch.fft.irfft(Z, n=self.num_random_features)
-        return self.species_scatter_sum(Z, atomic_numbers=atomic_numbers)
+        return self.species_scatter_sum(
+            Z,
+            atomic_numbers=atomic_numbers,
+            batch_ids=batch_ids,
+        )
 
     def init_args(self):
         return super().init_args() | {

--- a/franken/rf/heads.py
+++ b/franken/rf/heads.py
@@ -154,9 +154,13 @@ class RandomFeaturesHead(torch.nn.Module):
             assert (
                 0 <= kappa <= 1
             ), "The ratio of chemically informed feature feature map should be bounded between 0 and 1"
-            global_mean = torch.zeros((n_systems, Z.shape[1]), dtype=Z.dtype, device=Z.device)
+            global_mean = torch.zeros(
+                (n_systems, Z.shape[1]), dtype=Z.dtype, device=Z.device
+            )
             global_mean = global_mean.index_add(0, batch_ids, Z)
-            global_counts = torch.bincount(batch_ids, minlength=n_systems).to(dtype=Z.dtype)
+            global_counts = torch.bincount(batch_ids, minlength=n_systems).to(
+                dtype=Z.dtype
+            )
             global_mean = global_mean / global_counts.clamp_min(1).unsqueeze(-1)
             chemically_informed_descriptors = torch.cat(
                 (

--- a/franken/rf/heads.py
+++ b/franken/rf/heads.py
@@ -75,16 +75,29 @@ class RandomFeaturesHead(torch.nn.Module):
         a simple average, or will use a chemically-informed averaging method where features
         are averaged within each atomic type and concatenated across atomic types.
 
-        If ``batch_ids`` is ``None``, this behaves as before and returns a single
-        feature vector of shape ``[total_feature_dim]``.
-
-        If ``batch_ids`` is specified, this computes a per-system feature map and
-        returns a tensor of shape ``[n_systems, total_feature_dim]``.
+        Returns a feature per-system feature map of shape ``[n_systems, total_feature_dim]``.
         """
-        if batch_ids is None:
-            if self.num_species is None:
-                return Z.mean(0)
+        # Z: [Atoms(A), Features(F)]
+        # Out: [Systems(N), Features(F)[*(1+Species(S))]]
+        n_systems = 1
+        if batch_ids is not None:
+            batch_ids = batch_ids.to(dtype=torch.long)
+            n_systems = int(batch_ids.max().item()) + 1 if batch_ids.numel() > 0 else 0
+        dt = Z.dtype
+        dev = Z.device
+        n_species = self.num_species
+        n_rf = self.num_random_features
 
+        if n_systems <= 1:
+            global_mean = Z.mean(0, keepdim=True)
+        else:
+            assert batch_ids is not None
+            out = torch.zeros((n_systems, Z.shape[1]), dtype=dt, device=dev)
+            out = out.index_add(0, batch_ids, Z)
+            counts = torch.bincount(batch_ids, minlength=n_systems).to(dtype=dt)
+            global_mean = out / counts.clamp_min(1).unsqueeze(-1)
+
+        if n_species is not None:  # will return [N, S * F]
             assert (
                 atomic_numbers is not None
             ), "atomic_number should be specified when self.num_species is not None"
@@ -92,85 +105,37 @@ class RandomFeaturesHead(torch.nn.Module):
                 atomic_numbers, sorted=True, return_inverse=True
             )
             assert (
-                len(species_map) == self.num_species
-            ), f"The provided atomic numbers {species_map}, are of a different number than self.num_species {self.num_species}"
+                len(species_map) == n_species
+            ), f"The provided atomic numbers {species_map}, are of a different number than self.num_species {n_species}"
 
-            scatter_idxs = scatter_idxs.unsqueeze(-1).expand(
-                Z.size()
-            )  # ~[natoms, random_features_per_species] Broadcasting for backprop.
-            chemically_informed_descriptors = (
-                torch.zeros((self.num_species, self.num_random_features), dtype=Z.dtype)
-                .to(Z.device)
-                .scatter_reduce_(0, scatter_idxs, Z, "mean")
-            ) / self.num_species  # Normalize.
+            if n_systems > 1:
+                assert batch_ids is not None
+                # batched scatter indices
+                scatter_idxs = batch_ids * n_species + scatter_idxs  # [A]
+
+            # Scatter ids must be of the same size as Z for scatter_reduce_
+            scatter_idxs = scatter_idxs.unsqueeze(-1).expand_as(Z)
+            out = (
+                torch.zeros(
+                    (n_systems * n_species, n_rf), dtype=dt, device=dev
+                ).scatter_reduce_(0, scatter_idxs, Z, "mean", include_self=False)
+            ) / n_species  # [N*S, F]
+            chem_informed_features = out.view(n_systems, n_species, n_rf)  # [N, S, F]
 
             if self.chemically_informed_ratio is not None:
                 kappa = self.chemically_informed_ratio
                 assert (
                     0 <= kappa <= 1
                 ), "The ratio of chemically informed feature feature map should be bounded between 0 and 1"
-                chemically_informed_descriptors = torch.cat(
+                chem_informed_features = torch.cat(
                     (
-                        (1 - kappa) * Z.mean(0, keepdim=True),
-                        kappa * chemically_informed_descriptors,
-                    )
+                        (1 - kappa) * global_mean.unsqueeze(1),
+                        kappa * chem_informed_features,
+                    ),
+                    dim=1,
                 )
-            return chemically_informed_descriptors.view(-1)
-
-        batch_ids = batch_ids.to(dtype=torch.long)
-        n_systems = int(batch_ids.max().item()) + 1 if batch_ids.numel() > 0 else 0
-
-        if self.num_species is None:
-            out = torch.zeros((n_systems, Z.shape[1]), dtype=Z.dtype, device=Z.device)
-            out = out.index_add(0, batch_ids, Z)
-            counts = torch.bincount(batch_ids, minlength=n_systems).to(dtype=Z.dtype)
-            return out / counts.clamp_min(1).unsqueeze(-1)
-
-        assert (
-            atomic_numbers is not None
-        ), "atomic_number should be specified when self.num_species is not None"
-        species_map, scatter_idxs = torch.unique(
-            atomic_numbers, sorted=True, return_inverse=True
-        )
-        assert (
-            len(species_map) == self.num_species
-        ), f"The provided atomic numbers {species_map}, are of a different number than self.num_species {self.num_species}"
-
-        flat_scatter = (batch_ids * self.num_species + scatter_idxs).to(torch.long)
-        n_bins = n_systems * self.num_species
-        out = torch.zeros((n_bins, Z.shape[1]), dtype=Z.dtype, device=Z.device)
-        out = out.index_add(0, flat_scatter, Z)
-        counts = torch.bincount(flat_scatter, minlength=n_bins).to(dtype=Z.dtype)
-        out = out / counts.clamp_min(1).unsqueeze(-1)
-        chemically_informed_descriptors = out.view(
-            n_systems, self.num_species, self.num_random_features
-        )
-        chemically_informed_descriptors = (
-            chemically_informed_descriptors / self.num_species
-        )  # Normalize.
-
-        if self.chemically_informed_ratio is not None:
-            kappa = self.chemically_informed_ratio
-            assert (
-                0 <= kappa <= 1
-            ), "The ratio of chemically informed feature feature map should be bounded between 0 and 1"
-            global_mean = torch.zeros(
-                (n_systems, Z.shape[1]), dtype=Z.dtype, device=Z.device
-            )
-            global_mean = global_mean.index_add(0, batch_ids, Z)
-            global_counts = torch.bincount(batch_ids, minlength=n_systems).to(
-                dtype=Z.dtype
-            )
-            global_mean = global_mean / global_counts.clamp_min(1).unsqueeze(-1)
-            chemically_informed_descriptors = torch.cat(
-                (
-                    ((1 - kappa) * global_mean).unsqueeze(1),
-                    kappa * chemically_informed_descriptors,
-                ),
-                dim=1,
-            )
-
-        return chemically_informed_descriptors.view(n_systems, -1)
+            return chem_informed_features.reshape(n_systems, -1)  # [N, S*F]
+        return global_mean  # [N, F]
 
     def init_args(self):
         """Returns the arguments needed to re-initialize this class."""

--- a/franken/rf/model.py
+++ b/franken/rf/model.py
@@ -167,10 +167,10 @@ class FrankenPotential(torch.nn.Module):
             return model
 
     def feature_map(self, data: Configuration):
-        """Obtain an embedding of each atom, and map it through
-        random features. The RF mapping computes an average so
-        the final feature map is per-configuration, instead of
-        per-atom.
+        """Obtain an embedding of each atom, and map it through random features.
+
+        The RF mapping computes an average so the final feature map is
+        per-configuration, instead of per-atom.
         """
         gnn_descriptors = self.gnn.descriptors(data)
 
@@ -181,7 +181,32 @@ class FrankenPotential(torch.nn.Module):
         return self.rf.feature_map(
             normalized_descriptors,
             atomic_numbers=data.atomic_numbers,
+            batch_ids=None,
         )
+
+    def feature_map_batched(self, data: Configuration) -> torch.Tensor:
+        """Compute one random-feature map per system in a batched configuration.
+
+        Expects ``data.batch_ids`` to map each atom to a system index.
+        """
+        batch_ids = data.batch_ids
+        if batch_ids is None:
+            return self.feature_map(data).view(1, -1)
+
+        batch_ids = batch_ids.to(dtype=torch.long)
+        gnn_descriptors = self.gnn.descriptors(data)
+        normalized_descriptors = self.input_scaler(
+            gnn_descriptors,
+            atomic_numbers=data.atomic_numbers,
+        )
+        fmaps = self.rf.feature_map(
+            normalized_descriptors,
+            atomic_numbers=data.atomic_numbers,
+            batch_ids=batch_ids,
+        )
+        if fmaps.ndim == 1:
+            return fmaps.view(1, -1)
+        return fmaps
 
     def _feature_map_aux(self, atom_pos: torch.Tensor, data: Configuration):
         old_atom_pos = data.atom_pos
@@ -239,6 +264,86 @@ class FrankenPotential(torch.nn.Module):
         energy = data.natoms * torch.tensordot(weights, feature_map, dims=1)
 
         return energy
+
+    def energy_batched(
+        self, weights: Optional[torch.Tensor], data: Configuration
+    ) -> torch.Tensor:
+        """Compute per-system energies for a batched configuration.
+
+        Returns a tensor of shape ``[n_systems]`` for a single RF model and
+        ``[n_linear_models, n_systems]`` for multiple RF weight vectors.
+        """
+        if weights is None:
+            weights = self.rf.weights
+        if weights.ndim == 1:
+            weights = weights.unsqueeze(0)
+
+        feature_map = self.feature_map_batched(data).to(dtype=weights.dtype)
+        natoms = data.natoms.to(dtype=weights.dtype).view(-1)
+
+        # [S, F] @ [F, M] -> [S, M], then transpose to [M, S]
+        energies = torch.matmul(feature_map, weights.transpose(0, 1)).transpose(0, 1)
+        energies = energies * natoms.unsqueeze(0)
+
+        if energies.shape[0] == 1:
+            return energies[0]
+        return energies
+
+    def energy_and_forces_batched(
+        self,
+        data: Configuration,
+        weights: Optional[torch.Tensor] = None,
+        add_energy_shift: bool = True,
+        compute_forces: bool = True,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Infer per-system energies and per-atom forces for batched inputs."""
+        batch_ids = data.batch_ids
+        if batch_ids is None:
+            batch_ids = torch.zeros(
+                data.atomic_numbers.shape[0],
+                dtype=torch.long,
+                device=data.atomic_numbers.device,
+            )
+
+        if compute_forces:
+            if weights is not None and weights.ndim == 2 and weights.shape[0] > 1:
+                raise ValueError(
+                    "Batched force computation supports one RF model at a time."
+                )
+            if (
+                self.rf.weights.ndim == 2
+                and self.rf.weights.shape[0] > 1
+                and weights is None
+            ):
+                raise ValueError(
+                    "Batched force computation supports one RF model at a time."
+                )
+            data.atom_pos.requires_grad_(True)
+
+        energy = self.energy_batched(weights, data)
+
+        if compute_forces:
+            total_energy = energy.sum()
+            grad_energy = torch.autograd.grad(
+                outputs=[total_energy],
+                inputs=[data.atom_pos],
+            )[0]
+            forces = -grad_energy.detach()
+        else:
+            forces = None
+
+        if add_energy_shift:
+            shift = self.energy_shift(
+                data.atomic_numbers,
+                batch_ids=batch_ids.to(dtype=torch.long),
+                num_systems=int(data.natoms.numel()),
+            )
+            if energy.ndim == 1:
+                energy = energy + shift
+            else:
+                energy = energy + shift.unsqueeze(0)
+
+        return energy.detach(), forces
 
     def _energy_aux(
         self,

--- a/franken/rf/model.py
+++ b/franken/rf/model.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-from typing import Literal, Mapping, Optional, Tuple, Union
+from typing import List, Literal, Mapping, Optional, Tuple, Union
 
 import torch
 
@@ -170,7 +170,11 @@ class FrankenPotential(torch.nn.Module):
         """Obtain an embedding of each atom, and map it through random features.
 
         The RF mapping computes an average so the final feature map is
-        per-configuration, instead of per-atom.
+        per-structure, instead of per-atom. In case data contains multiple
+        structures, multiple feature maps are computed.
+
+        Returns:
+            feature_map: Tensor of size [n_structures, n_random_features]
         """
         gnn_descriptors = self.gnn.descriptors(data)
 
@@ -181,39 +185,16 @@ class FrankenPotential(torch.nn.Module):
         return self.rf.feature_map(
             normalized_descriptors,
             atomic_numbers=data.atomic_numbers,
-            batch_ids=None,
+            batch_ids=data.batch_ids,
         )
-
-    def feature_map_batched(self, data: Configuration) -> torch.Tensor:
-        """Compute one random-feature map per system in a batched configuration.
-
-        Expects ``data.batch_ids`` to map each atom to a system index.
-        """
-        batch_ids = data.batch_ids
-        if batch_ids is None:
-            return self.feature_map(data).view(1, -1)
-
-        batch_ids = batch_ids.to(dtype=torch.long)
-        gnn_descriptors = self.gnn.descriptors(data)
-        normalized_descriptors = self.input_scaler(
-            gnn_descriptors,
-            atomic_numbers=data.atomic_numbers,
-        )
-        fmaps = self.rf.feature_map(
-            normalized_descriptors,
-            atomic_numbers=data.atomic_numbers,
-            batch_ids=batch_ids,
-        )
-        if fmaps.ndim == 1:
-            return fmaps.view(1, -1)
-        return fmaps
 
     def _feature_map_aux(self, atom_pos: torch.Tensor, data: Configuration):
         old_atom_pos = data.atom_pos
         data.atom_pos = atom_pos
         random_features = self.feature_map(data)
         data.atom_pos = old_atom_pos
-        return random_features, random_features
+        # the differentiable output is summed over structures
+        return random_features.sum(0), random_features
 
     def grad_feature_map(
         self, data: Configuration
@@ -222,8 +203,8 @@ class FrankenPotential(torch.nn.Module):
         its gradient with respect to atomic positions
 
         Returns:
-         - forces_fmap : Tensor of size [n_random_features, n_atoms * 3]
-         - energy_fmap : Tensor of size [n_random_features]
+            forces_fmap : Tensor of size [n_random_features, n_atoms * 3]
+            energy_fmap : Tensor of size [n_structures, n_random_features]
         """
         if self._grad_fmap_jacfn is None:
             jac_chunk_size = self.get_jacobian_chunk_size(
@@ -254,96 +235,19 @@ class FrankenPotential(torch.nn.Module):
         Args:
             weights: The linear coefficients of the energy model.
             configuration: The molecular configuration whose energy to compute.
+        Returns:
+            energies : A tensor of size [n_models, n_structures].
+                ``n_models`` denotes the number of models present in the ``weights`` attribute;
+                ``n_structures`` the number of different structures present in the input data.
         """
         if weights is None:
             weights = self.rf.weights
-
-        feature_map = self.feature_map(data).to(dtype=weights.dtype)
-
-        # Contract the last dim of weights with the first of feature_map
-        energy = data.natoms * torch.tensordot(weights, feature_map, dims=1)
-
-        return energy
-
-    def energy_batched(
-        self, weights: Optional[torch.Tensor], data: Configuration
-    ) -> torch.Tensor:
-        """Compute per-system energies for a batched configuration.
-
-        Returns a tensor of shape ``[n_systems]`` for a single RF model and
-        ``[n_linear_models, n_systems]`` for multiple RF weight vectors.
-        """
-        if weights is None:
-            weights = self.rf.weights
-        if weights.ndim == 1:
-            weights = weights.unsqueeze(0)
-
-        feature_map = self.feature_map_batched(data).to(dtype=weights.dtype)
-        natoms = data.natoms.to(dtype=weights.dtype).view(-1)
-
-        # [S, F] @ [F, M] -> [S, M], then transpose to [M, S]
-        energies = torch.matmul(feature_map, weights.transpose(0, 1)).transpose(0, 1)
-        energies = energies * natoms.unsqueeze(0)
-
-        if energies.shape[0] == 1:
-            return energies[0]
+        # weights: [num weights(M), num features(F)]
+        feature_map = self.feature_map(data).to(dtype=weights.dtype)  # [N, F]
+        natoms = data.natoms.to(dtype=weights.dtype).view(-1)  # [N]
+        energies = torch.matmul(feature_map, weights.T).T  # [M, N]
+        energies = natoms[None, :] * energies
         return energies
-
-    def energy_and_forces_batched(
-        self,
-        data: Configuration,
-        weights: Optional[torch.Tensor] = None,
-        add_energy_shift: bool = True,
-        compute_forces: bool = True,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
-        """Infer per-system energies and per-atom forces for batched inputs."""
-        batch_ids = data.batch_ids
-        if batch_ids is None:
-            batch_ids = torch.zeros(
-                data.atomic_numbers.shape[0],
-                dtype=torch.long,
-                device=data.atomic_numbers.device,
-            )
-
-        if compute_forces:
-            if weights is not None and weights.ndim == 2 and weights.shape[0] > 1:
-                raise ValueError(
-                    "Batched force computation supports one RF model at a time."
-                )
-            if (
-                self.rf.weights.ndim == 2
-                and self.rf.weights.shape[0] > 1
-                and weights is None
-            ):
-                raise ValueError(
-                    "Batched force computation supports one RF model at a time."
-                )
-            data.atom_pos.requires_grad_(True)
-
-        energy = self.energy_batched(weights, data)
-
-        if compute_forces:
-            total_energy = energy.sum()
-            grad_energy = torch.autograd.grad(
-                outputs=[total_energy],
-                inputs=[data.atom_pos],
-            )[0]
-            forces = -grad_energy.detach()
-        else:
-            forces = None
-
-        if add_energy_shift:
-            shift = self.energy_shift(
-                data.atomic_numbers,
-                batch_ids=batch_ids.to(dtype=torch.long),
-                num_systems=int(data.natoms.numel()),
-            )
-            if energy.ndim == 1:
-                energy = energy + shift
-            else:
-                energy = energy + shift.unsqueeze(0)
-
-        return energy.detach(), forces
 
     def _energy_aux(
         self,
@@ -353,9 +257,9 @@ class FrankenPotential(torch.nn.Module):
     ):
         old_atom_pos = data.atom_pos
         data.atom_pos = atom_pos
-        energy = self.energy(weights, data)
+        energy = self.energy(weights, data)  # [M, N]
         data.atom_pos = old_atom_pos
-        return energy, energy
+        return energy.sum(1), energy
 
     def grad_energy_func(
         self, weights: Optional[torch.Tensor], data: Configuration
@@ -393,7 +297,9 @@ class FrankenPotential(torch.nn.Module):
             self._grad_energy_jacfn = jacfwd(
                 self._energy_aux, argnums=1, has_aux=True, chunk_size=jac_chunk_size
             )
-        out = self._grad_energy_jacfn(weights, data.atom_pos, data)
+        out = self._grad_energy_jacfn(
+            weights, data.atom_pos, data
+        )  # ([M, A, 3], [M, N])
         return out
 
     def grad_energy_autograd(
@@ -418,28 +324,27 @@ class FrankenPotential(torch.nn.Module):
         # Ensure atom positions require gradients
         data.atom_pos.requires_grad_(True)
         # Compute the energy
-        energy = self.energy(weights, data)
-
-        if energy.ndim == 0:
-            # Scalar case, single gradient
-            gradient = torch.autograd.grad(outputs=[energy], inputs=[data.atom_pos])[0]
-        else:
-            # Vector case, compute gradients for each element independently.
-            # This happens when several energies are computed when testing
-            # multiple models at the same time.
-            gradients: list[torch.Tensor] = []
-            for i in range(energy.shape[0]):
-                grad_i = torch.autograd.grad(
-                    outputs=[energy[i]],
-                    inputs=[data.atom_pos],
-                    retain_graph=True,
-                )[0]
-                assert grad_i is not None
-                gradients.append(grad_i)
-            # Stack gradients along a new dimension
-            gradient = torch.stack(gradients, dim=0)
-
-        return gradient, energy
+        energy = self.energy(weights, data)  # [M, N]
+        n_sols, n_sys = energy.shape
+        n_atoms = data.atom_pos.shape[0]
+        # Compute energy gradients for each model (M) independently.
+        gradients: List[torch.Tensor] = []
+        for i in range(n_sols):
+            cur_energy: torch.Tensor = energy[i]
+            # complex type annotation required by the obsolete jit.script system
+            grad_out: List[Optional[torch.Tensor]] = [torch.ones_like(cur_energy)]
+            grad_i = torch.autograd.grad(
+                outputs=[cur_energy],
+                inputs=[data.atom_pos],
+                grad_outputs=grad_out,
+                retain_graph=i < n_sols - 1,
+            )[0]
+            assert grad_i is not None
+            gradients.append(grad_i)
+        # Stack gradients along a new dimension
+        gradient = torch.stack(gradients, dim=0)
+        gradient = gradient.view(n_sols, n_atoms, 3)
+        return gradient, energy  # ([M, A, 3], [M, N])
 
     def get_jacobian_chunk_size(self, func, func_inputs, argnums=0) -> int:
         if hasattr(self, "_auto_jac_chunk_size"):
@@ -495,6 +400,7 @@ class FrankenPotential(torch.nn.Module):
             given configuration. If multiple models are given, the forces will have shape :code:`[n_linear_models, n_atoms, 3]`,
             otherwise they will have shape :code:`[n_atoms, 3]`.
         """
+        natoms = torch.atleast_1d(data.natoms)
         if forces_mode == "torch.func":
             with torch.no_grad():
                 grad_energy, energy = self.grad_energy_func(weights, data)
@@ -510,8 +416,12 @@ class FrankenPotential(torch.nn.Module):
             raise ValueError(f"forces_mode '{forces_mode}' is not valid.")
 
         if add_energy_shift:
-            energy = energy + self.energy_shift(data.atomic_numbers)
-        return energy.detach(), forces
+            energy = energy + self.energy_shift(
+                data.atomic_numbers,
+                batch_ids=data.batch_ids,
+                num_systems=int(natoms.numel()),
+            )
+        return energy, forces  # ([M, N], [M, A, 3])
 
     def energy_and_forces_from_fmaps(
         self,
@@ -521,21 +431,54 @@ class FrankenPotential(torch.nn.Module):
         weights: Optional[torch.Tensor] = None,
         add_energy_shift: bool = True,
     ):
+        """Compute energies and forces from pre-computed featuremaps.
+        This function does not require calling the underlying GNN.
+
+        Args:
+            data : Configuration object describing one or more atomic structures
+            energy_fmap : Tensor of size [n_structures, num_random_features] containing the
+                original feature map
+            forces_fmap : Tensor of size [num_random_features, num_atoms * 3] containing the
+                gradients of the original feature map
+            weights: Optional tensor of size [num_models, num_random_features]. This contains
+                the weights of a trained RF model. If no weights are provided, the weights
+                contained in the RF model attached to this class will be used. Energies and forces
+                can be computed for multiple models simulatenously by passing in multiple weight
+                vectors (arranged in 2D).
+        Returns:
+            energies : Tensor of size [n_models, n_structures]
+            forces   : Tensor of size [n_models, n_atoms, 3]
+        """
         if weights is None:
             weights = self.rf.weights
-        energy = torch.tensordot(
-            weights,
-            data.natoms * energy_fmap,
-            dims=([1], [0]),  # type: ignore
-        )
-        forces = torch.tensordot(
-            weights,
-            data.natoms * forces_fmap.view(forces_fmap.shape[0], -1, 3),
-            dims=([1], [0]),  # type: ignore
-        )
+        natoms = torch.atleast_1d(data.natoms)
+        # Consistency checks
+        assert energy_fmap.ndim == 2, f"Energy map dimensions {energy_fmap.shape}"
+        assert forces_fmap.ndim == 2, f"Forces map dimensions {forces_fmap.shape}"
+        assert weights.ndim == 2, f"Weights dimensions {weights.shape}"
+        assert (
+            energy_fmap.shape[1] == forces_fmap.shape[0]
+        ), f"{forces_fmap.shape=} {energy_fmap.shape=}"
+        assert (
+            weights.shape[1] == forces_fmap.shape[0]
+        ), f"{weights.shape=} {forces_fmap.shape=}"
+
+        energies = natoms[None, :] * torch.matmul(energy_fmap, weights.T).T  # [M, N]
+        forces = torch.matmul(weights, forces_fmap)  # [M, A*3]
+        forces = forces.view(forces.shape[0], -1, 3)  # [M, A, 3]
+        if data.batch_ids is None:
+            forces = forces * natoms
+        else:
+            natoms_mul = torch.gather(natoms, 0, data.batch_ids)
+            forces = forces * natoms_mul[None, :, None]
+
         if add_energy_shift:
-            energy = energy + self.energy_shift(data.atomic_numbers)
-        return energy, forces
+            energies = energies + self.energy_shift(
+                data.atomic_numbers,
+                batch_ids=data.batch_ids,
+                num_systems=int(natoms.numel()),
+            )
+        return energies, forces
 
     def forward(
         self,
@@ -556,8 +499,13 @@ class FrankenPotential(torch.nn.Module):
         else:
             grad_energy, energy = self.grad_energy_autograd(weights, data)
             assert grad_energy is not None
-            forces = -grad_energy.detach()
             energy = energy.detach()
+            forces = -grad_energy.detach()
         if add_energy_shift:
-            energy = energy + self.energy_shift(data.atomic_numbers)
+            natoms = torch.atleast_1d(data.natoms)
+            energy = energy + self.energy_shift(
+                data.atomic_numbers,
+                batch_ids=data.batch_ids,
+                num_systems=int(natoms.numel()),
+            )
         return energy, forces

--- a/franken/trainers/rf_cuda_lowmem.py
+++ b/franken/trainers/rf_cuda_lowmem.py
@@ -13,7 +13,7 @@ from torch import Tensor
 import franken.metrics
 from franken.metrics.base import BaseMetric
 import franken.utils.distributed as dist_utils
-from franken.data.base import Target
+from franken.data.base import Configuration, Target
 from franken.rf.model import FrankenPotential
 from franken.trainers import BaseTrainer
 from franken.trainers.log_utils import (
@@ -254,12 +254,12 @@ class RandomFeaturesTrainer(BaseTrainer):
                 predictions = Target(
                     *model.energy_and_forces_from_fmaps(
                         data,
-                        energy_fmap=self.energy_fmap[i],
+                        energy_fmap=self.energy_fmap[i][None, ...],
                         forces_fmap=self.forces_fmap[i],
                         weights=all_weights,
                         add_energy_shift=False,  # since it's always train here
                     )
-                )
+                ).detach()
             else:
                 if all_weights is None or all_weights.shape[0] <= 100:
                     forces_mode = "torch.autograd"
@@ -272,7 +272,7 @@ class RandomFeaturesTrainer(BaseTrainer):
                         forces_mode=forces_mode,
                         add_energy_shift=(False if split == DataSplit.TRAIN else True),
                     )
-                )
+                ).detach()
             if torch.any(torch.isnan(predictions.energy)):
                 logger.warning(
                     f"Configuration {i} - {split_name} has NaNs in energy predictions"
@@ -284,10 +284,7 @@ class RandomFeaturesTrainer(BaseTrainer):
                     f"Configuration {i} - {split_name} has NaNs in force predictions"
                 )
             for metric in metric_objects:
-                if metric.requires_species:
-                    metric.update(predictions, targets, data.atomic_numbers)
-                else:
-                    metric.update(predictions, targets)
+                metric.update(predictions, targets, data)
 
         num_models = (
             all_weights.shape[0]
@@ -330,17 +327,12 @@ class RandomFeaturesTrainer(BaseTrainer):
                     # scalar metric
                     results.append(dict(name=name, value=v.item()))
                 else:
-                    # per-species metric:
+                    # per-species metric "<metric_name>_<species>: <metric_val>"
                     counts = metric_counters[name]
 
                     for z in range(v.shape[0]):
                         if counts[z] > 0:
-                            results.append(
-                                dict(
-                                    name=f"{name}_{z}",
-                                    value=v[z].item(),
-                                )
-                            )
+                            results.append(dict(name=f"{name}_{z}", value=v[z].item()))
             raw_logs.append(results)
 
         assert len(raw_logs) == len(log_collection)
@@ -412,15 +404,19 @@ class RandomFeaturesTrainer(BaseTrainer):
         )
 
         for i, (data, targets) in enumerate(progress_bar):
+            assert isinstance(data, Configuration)
             data = data.to(device=self.device)
             targets = targets.to(device=self.device)
 
             energy_per_atom = targets.energy / data.natoms
             forces_per_atom = targets.forces / data.natoms
 
-            forces_fmap, energy_fmap = model.grad_feature_map(data)
-            energy_fmap = energy_fmap.to(dtype=self.buffer_dt)
+            assert data.natoms.numel() == 1, "Batched training is not supported"
+            forces_fmap, energy_fmap = model.grad_feature_map(
+                data
+            )  # ([F, A, 3], [N, F])
 
+            energy_fmap = energy_fmap.squeeze(0).to(dtype=self.buffer_dt)
             rank1_update(self.covariance, self.diag_energy, energy_fmap, upper=True)
             self.coeffs_energy.add_(energy_fmap, alpha=energy_per_atom.item())
 

--- a/franken/trainers/rf_cuda_lowmem.py
+++ b/franken/trainers/rf_cuda_lowmem.py
@@ -60,8 +60,7 @@ class RandomFeaturesTrainer(BaseTrainer):
         save_fmaps (bool):
             Whether or not to save feature-maps for the training set. Saving them
             requires extra memory (linear in the training-set size), but speeds up
-            the :meth:`~franken.trainers.FrankenPotential.evaluate` method on training
-            data. Defaults to True.
+            the ``evaluate()`` path on training data. Defaults to True.
     """
 
     def __init__(
@@ -106,25 +105,19 @@ class RandomFeaturesTrainer(BaseTrainer):
             model (FrankenPotential): The model which defines GNN and random features.
             solver_params (dict): Parameters for the solver which actually
                 performs the fit. This argument allows to specify multiple parameters,
-                for each of which we will perform a fit. For example
-
-                >>> solver_params = {
-                >>>     "l2_penalty": [1e-6, 1e-4],
-                >>>     "force_weight": [0.5]
-                >>> }
-
+                for each of which we will perform a fit. For example, passing
+                ``{"l2_penalty": [1e-6, 1e-4], "force_weight": [0.5]}``
                 will result in two different models, one with :code:`l2_penalty=1e-6, force_weight=0.5`
                 and one with :code:`l2_penalty=1e-4, force_weight=0.5`. This way of specifying solver
                 parameters allows to easily perform a grid-search.
 
         Returns:
-            logs (LogCollection): Logs which contain all parameters related
-                to the fitting, as well as timings.
-            weights (torch.Tensor): Weights which were learned during the fit.
+            tuple[LogCollection, torch.Tensor]:
+                The fitting logs, together with the learned weights.
 
         Note:
             More information about the available solver parameters can be found under the
-            :meth:`solve` method.
+            ``solve()`` method.
         """
         if self.device.type == "cuda":
             # Patch E3NN for batched jacobians!

--- a/franken/utils/jac.py
+++ b/franken/utils/jac.py
@@ -82,7 +82,7 @@ def jacfwd(
     # Dynamo does not support HOP composition if their inner function is
     # annotated with @functools.wraps(...). We circumvent this issue by applying
     # wraps only if we're not tracing with dynamo.
-    if not torch._dynamo.is_compiling():
+    if not torch.compiler.is_compiling():
         wrapper_fn = wraps(func)(wrapper_fn)
 
     return wrapper_fn

--- a/franken/utils/misc.py
+++ b/franken/utils/misc.py
@@ -231,8 +231,12 @@ def is_cuda_out_of_memory(exception: BaseException) -> bool:
     return (
         isinstance(exception, RuntimeError)
         and len(exception.args) == 1
-        and "CUDA" in exception.args[0]
-        and "out of memory" in exception.args[0]
+        and ((
+            "CUDA" in exception.args[0]
+            and "out of memory" in exception.args[0]
+        ) or (
+            "CUDACachingAllocator.cpp" in exception.args[0]
+        ))
     )
 
 

--- a/franken/utils/misc.py
+++ b/franken/utils/misc.py
@@ -231,12 +231,10 @@ def is_cuda_out_of_memory(exception: BaseException) -> bool:
     return (
         isinstance(exception, RuntimeError)
         and len(exception.args) == 1
-        and ((
-            "CUDA" in exception.args[0]
-            and "out of memory" in exception.args[0]
-        ) or (
-            "CUDACachingAllocator.cpp" in exception.args[0]
-        ))
+        and (
+            ("CUDA" in exception.args[0] and "out of memory" in exception.args[0])
+            or ("CUDACachingAllocator.cpp" in exception.args[0])
+        )
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 keywords = [
     "franken", "potentials", "molecular dynamics",

--- a/tests/test_backbones_utils.py
+++ b/tests/test_backbones_utils.py
@@ -46,6 +46,8 @@ def test_cache_dir_default(mock_cache_folder):
                 assert result == mock_cache_folder / ".franken"
                 # Ensure that the path exists
                 mock_exists.assert_called_once()
+                # Reset cache dir. Avoids leaving stale state around
+                franken.backbones.utils.CacheDir.directory = None
 
 
 def test_cache_dir_with_env_var(mock_cache_folder):
@@ -62,6 +64,8 @@ def test_cache_dir_with_env_var(mock_cache_folder):
             assert str(result) == str(mock_cache_folder)
             # Ensure that the path exists
             mock_exists.assert_called_once()
+            # Reset cache dir. Avoids leaving stale state around
+            franken.backbones.utils.CacheDir.directory = None
 
 
 def test_download_checkpoint_name_error():

--- a/tests/test_franken_potential.py
+++ b/tests/test_franken_potential.py
@@ -331,12 +331,12 @@ class TestModelGradients:
             cfg_batched, weights=weights, forces_mode="torch.autograd"
         )
         torch.testing.assert_close(energy_autograd_batched, energy_autograd, msg=f"Batched energies not equal: actual={energy_autograd_batched}  expected={energy_autograd}")
-        torch.testing.assert_close(forces_autograd_batched, forces_autograd, msg=f"Batched forces (autograd) not equal: actual={forces_autograd_batched}  expected={forces_autograd}")
+        torch.testing.assert_close(forces_autograd_batched, forces_autograd, rtol=1e-4, atol=1e-4, msg=f"Batched forces (autograd) not equal: actual={forces_autograd_batched}  expected={forces_autograd}")
         energy_func_batched, forces_func_batched = model.energy_and_forces(
             cfg_batched, weights=weights, forces_mode="torch.func"
         )
         torch.testing.assert_close(energy_func_batched, energy_autograd, msg=f"Batched energies not equal: actual={energy_autograd_batched}  expected={energy_autograd}")
-        torch.testing.assert_close(forces_func_batched, forces_autograd, msg=f"Batched forces (func) not equal: actual={forces_autograd_batched}  expected={forces_autograd}")
+        torch.testing.assert_close(forces_func_batched, forces_autograd, rtol=1e-4, atol=1e-4, msg=f"Batched forces (func) not equal: actual={forces_autograd_batched}  expected={forces_autograd}")
 
     @pytest.mark.parametrize("gnn_cfg", DEFAULT_GNN_CONFIGS)
     def test_gradients_real(self, rf_cfg, device, multiweights: bool, gnn_cfg):
@@ -511,7 +511,7 @@ class TestEnergyShift:
             cfg_batched, weights=weights, forces_mode="torch.autograd", add_energy_shift=True
         )
         torch.testing.assert_close(e_ag, e_ag_batch, msg=f"Batched energies not equal: actual={e_ag}  expected={e_ag_batch}")
-        torch.testing.assert_close(f_ag, f_ag_batch, msg=f"Batched forces not equal: actual={f_ag}  expected={f_ag_batch}")
+        torch.testing.assert_close(f_ag, f_ag_batch, rtol=1e-4, atol=1e-4, msg=f"Batched forces not equal: actual={f_ag}  expected={f_ag_batch}")
 
 
 @pytest.mark.parametrize("gnn_cfg", DEFAULT_GNN_CONFIGS)

--- a/tests/test_franken_potential.py
+++ b/tests/test_franken_potential.py
@@ -330,13 +330,13 @@ class TestModelGradients:
         energy_autograd_batched, forces_autograd_batched = model.energy_and_forces(
             cfg_batched, weights=weights, forces_mode="torch.autograd"
         )
-        torch.testing.assert_close(energy_autograd_batched, energy_autograd, msg="Batched energies not equal")
-        torch.testing.assert_close(forces_autograd_batched, forces_autograd, msg="Batched forces not equal")
+        torch.testing.assert_close(energy_autograd_batched, energy_autograd, msg=f"Batched energies not equal: actual={energy_autograd_batched}  expected={energy_autograd}")
+        torch.testing.assert_close(forces_autograd_batched, forces_autograd, msg=f"Batched forces (autograd) not equal: actual={forces_autograd_batched}  expected={forces_autograd}")
         energy_func_batched, forces_func_batched = model.energy_and_forces(
             cfg_batched, weights=weights, forces_mode="torch.func"
         )
-        torch.testing.assert_close(energy_func_batched, energy_autograd, msg="Batched energies not equal")
-        torch.testing.assert_close(forces_func_batched, forces_autograd, msg="Batched forces not equal")
+        torch.testing.assert_close(energy_func_batched, energy_autograd, msg=f"Batched energies not equal: actual={energy_autograd_batched}  expected={energy_autograd}")
+        torch.testing.assert_close(forces_func_batched, forces_autograd, msg=f"Batched forces (func) not equal: actual={forces_autograd_batched}  expected={forces_autograd}")
 
     @pytest.mark.parametrize("gnn_cfg", DEFAULT_GNN_CONFIGS)
     def test_gradients_real(self, rf_cfg, device, multiweights: bool, gnn_cfg):
@@ -504,13 +504,14 @@ class TestEnergyShift:
         e_ag2, f_ag2 = model.energy_and_forces(
             cfg2, weights=weights, forces_mode="torch.autograd", add_energy_shift=True
         )
+        assert f_ag1 is not None and f_ag2 is not None
         e_ag = torch.cat([e_ag1, e_ag2], dim=1)
         f_ag = torch.cat([f_ag1, f_ag2], dim=1)
         e_ag_batch, f_ag_batch = model.energy_and_forces(
             cfg_batched, weights=weights, forces_mode="torch.autograd", add_energy_shift=True
         )
-        torch.testing.assert_close(e_ag, e_ag_batch, msg="Batched energies not equal")
-        torch.testing.assert_close(f_ag, f_ag_batch, msg="Batched forces not equal")
+        torch.testing.assert_close(e_ag, e_ag_batch, msg=f"Batched energies not equal: actual={e_ag}  expected={e_ag_batch}")
+        torch.testing.assert_close(f_ag, f_ag_batch, msg=f"Batched forces not equal: actual={f_ag}  expected={f_ag_batch}")
 
 
 @pytest.mark.parametrize("gnn_cfg", DEFAULT_GNN_CONFIGS)

--- a/tests/test_franken_potential.py
+++ b/tests/test_franken_potential.py
@@ -227,7 +227,7 @@ def test_inference_force_mode(rf_cfg, device, multiweights: bool):
 
         if multiweights:
             dummy_multiweights = torch.randn(
-                (10,) + model.rf.weights.shape,
+                (10, model.rf.weights.shape[-1]),
                 dtype=model.rf.weights.dtype,
                 device=model.rf.weights.device,
             )
@@ -278,7 +278,7 @@ class TestModelGradients:
                 rf_config=rf_cfg,
             ).to(device)
 
-        num_lin_models = 10 if multiweights else 1
+        num_lin_models = 8 if multiweights else 1
         weights = torch.randn(
             (num_lin_models, model.rf.total_random_features), device=device
         )
@@ -295,6 +295,48 @@ class TestModelGradients:
         )
         torch.testing.assert_close(energy_func, energy_autograd, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(forces_func, forces_autograd, rtol=1e-3, atol=1e-3)
+    
+    def test_batched_gradients_mocked(self, rf_cfg, device, multiweights):
+        num_atoms = 10
+        num_lin_models = 8 if multiweights else 1
+        dtype = torch.float32
+        with mocked_gnn(device=device, dtype=dtype, feature_dim=32):
+            model = FrankenPotential(
+                gnn_config="test", # type: ignore
+                rf_config=rf_cfg,
+            ).to(device)
+
+        weights = torch.randn(
+            (num_lin_models, model.rf.total_random_features), device=device
+        )
+        atomic_nums = torch.randint(1, 100, (num_atoms,))
+        cfg1 = Configuration(
+            torch.randn(num_atoms, 3, dtype=dtype), atomic_nums, torch.tensor(num_atoms)
+        ).to(device)
+        cfg2 = Configuration(
+            torch.randn(num_atoms, 3, dtype=dtype), atomic_nums, torch.tensor(num_atoms)
+        ).to(device)
+        cfg_batched = Configuration.concatenate([cfg1, cfg2])
+
+        energy_autograd_1, forces_autograd_1 = model.energy_and_forces(
+            cfg1, weights=weights, forces_mode="torch.autograd"
+        )
+        energy_autograd_2, forces_autograd_2 = model.energy_and_forces(
+            cfg2, weights=weights, forces_mode="torch.autograd"
+        )
+        assert forces_autograd_1 is not None and forces_autograd_2 is not None
+        energy_autograd = torch.cat([energy_autograd_1, energy_autograd_2], dim=1)
+        forces_autograd = torch.cat([forces_autograd_1, forces_autograd_2], dim=1)
+        energy_autograd_batched, forces_autograd_batched = model.energy_and_forces(
+            cfg_batched, weights=weights, forces_mode="torch.autograd"
+        )
+        torch.testing.assert_close(energy_autograd_batched, energy_autograd, msg="Batched energies not equal")
+        torch.testing.assert_close(forces_autograd_batched, forces_autograd, msg="Batched forces not equal")
+        energy_func_batched, forces_func_batched = model.energy_and_forces(
+            cfg_batched, weights=weights, forces_mode="torch.func"
+        )
+        torch.testing.assert_close(energy_func_batched, energy_autograd, msg="Batched energies not equal")
+        torch.testing.assert_close(forces_func_batched, forces_autograd, msg="Batched forces not equal")
 
     @pytest.mark.parametrize("gnn_cfg", DEFAULT_GNN_CONFIGS)
     def test_gradients_real(self, rf_cfg, device, multiweights: bool, gnn_cfg):
@@ -322,10 +364,158 @@ class TestModelGradients:
         torch.testing.assert_close(forces_func, forces_autograd, rtol=1e-3, atol=1e-3)
 
 
+@pytest.mark.parametrize("rf_cfg", RF_PARAMETRIZE)
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("multiweights", [True, False])
+class TestEnergyShift:
+    num_atoms = 10
+    atomic_nums = torch.tensor([1, 1, 1, 1, 1, 8, 8, 8, 8, 8])
+    atomic_energies = {1: -1.0, 8: 0.5}
+    dtype = torch.float32
+
+    def test_simple(self, rf_cfg, device, multiweights):
+        with mocked_gnn(device=device, dtype=self.dtype, feature_dim=32):
+            model = FrankenPotential(
+                gnn_config="test", # type: ignore
+                rf_config=rf_cfg,
+                atomic_energies=self.atomic_energies,
+                num_species=2,
+            ).to(device)
+
+        num_lin_models = 8 if multiweights else 1
+        weights = torch.randn(
+            (num_lin_models, model.rf.total_random_features), device=device
+        )
+        data = Configuration(
+            torch.randn(self.num_atoms, 3, dtype=self.dtype),
+            self.atomic_nums,
+            torch.tensor(self.num_atoms),
+        ).to(device)
+
+        e_ag, f_ag = model.energy_and_forces(
+            data, weights=weights, forces_mode="torch.autograd", add_energy_shift=False
+        )
+        e_ag_shift, f_ag_shift = model.energy_and_forces(
+            data, weights=weights, forces_mode="torch.autograd", add_energy_shift=True
+        )
+        torch.testing.assert_close(f_ag, f_ag_shift)
+        torch.testing.assert_close(e_ag + self.atomic_energies[1] * 5 + self.atomic_energies[8] * 5, e_ag_shift) 
+
+        e_fn, f_fn = model.energy_and_forces(
+            data, weights=weights, forces_mode="torch.func", add_energy_shift=False
+        )
+        e_fn_shift, f_fn_shift = model.energy_and_forces(
+            data, weights=weights, forces_mode="torch.func", add_energy_shift=True
+        )
+        torch.testing.assert_close(f_fn, f_fn_shift)
+        torch.testing.assert_close(e_fn + self.atomic_energies[1] * 5 + self.atomic_energies[8] * 5, e_fn_shift) 
+
+    def test_w_feature_maps(self, rf_cfg, device, multiweights):
+        with mocked_gnn(device=device, dtype=self.dtype, feature_dim=32):
+            model = FrankenPotential(
+                gnn_config="test", # type: ignore
+                rf_config=rf_cfg,
+                atomic_energies=self.atomic_energies,
+                num_species=2,
+            ).to(device)
+        num_lin_models = 8 if multiweights else 1
+        weights = torch.randn(
+            (num_lin_models, model.rf.total_random_features), device=device
+        )
+        data = Configuration(
+            torch.randn(self.num_atoms, 3, dtype=self.dtype),
+            self.atomic_nums,
+            torch.tensor(self.num_atoms),
+        ).to(device)
+
+        ffmap, efmap = model.grad_feature_map(data)
+        ffmap = ffmap.view(ffmap.shape[0], -1)
+        e_from_fmaps, f_from_fmaps = model.energy_and_forces_from_fmaps(
+            data, energy_fmap=efmap, forces_fmap=ffmap, weights=weights, add_energy_shift=False
+        )
+        e_from_fmaps_shift, f_from_fmaps_shift = model.energy_and_forces_from_fmaps(
+            data, energy_fmap=efmap, forces_fmap=ffmap, weights=weights, add_energy_shift=True
+        )
+        torch.testing.assert_close(f_from_fmaps, f_from_fmaps_shift)
+        torch.testing.assert_close(e_from_fmaps + self.atomic_energies[1] * 5 + self.atomic_energies[8] * 5, e_from_fmaps_shift) 
+
+    def test_unknown_species(self, rf_cfg, device, multiweights):
+        """Shift for unknown species should be 0"""
+        atomic_nums = torch.tensor([1, 1, 1, 1, 1, 8, 8, 8, 9, 10])
+        with mocked_gnn(device=device, dtype=self.dtype, feature_dim=32):
+            model = FrankenPotential(
+                gnn_config="test", # type: ignore
+                rf_config=rf_cfg,
+                atomic_energies=self.atomic_energies,
+                num_species=2,
+            ).to(device)
+        num_lin_models = 8 if multiweights else 1
+        weights = torch.randn(
+            (num_lin_models, model.rf.total_random_features), device=device
+        )
+        data = Configuration(
+            torch.randn(self.num_atoms, 3, dtype=self.dtype),
+            atomic_nums,
+            torch.tensor(self.num_atoms),
+        ).to(device)
+
+        e_ag, f_ag = model.energy_and_forces(
+            data, weights=weights, forces_mode="torch.autograd", add_energy_shift=False
+        )
+        e_ag_shift, f_ag_shift = model.energy_and_forces(
+            data, weights=weights, forces_mode="torch.autograd", add_energy_shift=True
+        )
+        torch.testing.assert_close(f_ag, f_ag_shift)
+        torch.testing.assert_close(e_ag + self.atomic_energies[1] * 5 + self.atomic_energies[8] * 3, e_ag_shift) 
+
+        e_fn, f_fn = model.energy_and_forces(
+            data, weights=weights, forces_mode="torch.func", add_energy_shift=False
+        )
+        e_fn_shift, f_fn_shift = model.energy_and_forces(
+            data, weights=weights, forces_mode="torch.func", add_energy_shift=True
+        )
+        torch.testing.assert_close(f_fn, f_fn_shift)
+        torch.testing.assert_close(e_fn + self.atomic_energies[1] * 5 + self.atomic_energies[8] * 3, e_fn_shift) 
+    
+    def test_batched(self, rf_cfg, device, multiweights):
+        with mocked_gnn(device=device, dtype=self.dtype, feature_dim=32):
+            model = FrankenPotential(
+                gnn_config="test", # type: ignore
+                rf_config=rf_cfg,
+                atomic_energies=self.atomic_energies,
+                num_species=2,
+            ).to(device)
+        num_lin_models = 8 if multiweights else 1
+        weights = torch.randn(
+            (num_lin_models, model.rf.total_random_features), device=device
+        )
+        atomic_nums = torch.randint(1, 100, (self.num_atoms,))
+        cfg1 = Configuration(
+            torch.randn(self.num_atoms, 3, dtype=self.dtype), atomic_nums, torch.tensor(self.num_atoms)
+        ).to(device)
+        cfg2 = Configuration(
+            torch.randn(self.num_atoms, 3, dtype=self.dtype), atomic_nums, torch.tensor(self.num_atoms)
+        ).to(device)
+        cfg_batched = Configuration.concatenate([cfg1, cfg2])
+
+        e_ag1, f_ag1 = model.energy_and_forces(
+            cfg1, weights=weights, forces_mode="torch.autograd", add_energy_shift=True
+        )
+        e_ag2, f_ag2 = model.energy_and_forces(
+            cfg2, weights=weights, forces_mode="torch.autograd", add_energy_shift=True
+        )
+        e_ag = torch.cat([e_ag1, e_ag2], dim=1)
+        f_ag = torch.cat([f_ag1, f_ag2], dim=1)
+        e_ag_batch, f_ag_batch = model.energy_and_forces(
+            cfg_batched, weights=weights, forces_mode="torch.autograd", add_energy_shift=True
+        )
+        torch.testing.assert_close(e_ag, e_ag_batch, msg="Batched energies not equal")
+        torch.testing.assert_close(f_ag, f_ag_batch, msg="Batched forces not equal")
+
+
 @pytest.mark.parametrize("gnn_cfg", DEFAULT_GNN_CONFIGS)
 @pytest.mark.parametrize("device", DEVICES)
-@pytest.mark.parametrize("atomic_energies", [None, {7: 1.0, 26: 10.0}])
-def test_autotune(gnn_cfg, device, atomic_energies):
+def test_autotune(gnn_cfg, device):
     loaders = init_loaders(
         gnn_cfg,
         DATASET_REGISTRY.get_path("test", "train", None, False),

--- a/tests/test_mace_wrap.py
+++ b/tests/test_mace_wrap.py
@@ -2,10 +2,48 @@
 
 import pytest
 import torch
+from mace.data import Configuration
 
 from mace.tools import AtomicNumberTable, atomic_numbers_to_indices, to_one_hot
 
+from franken.backbones.utils import load_checkpoint
 from franken.backbones.wrappers.mace_wrap import atom_numbers_to_node_attrs
+from franken.config import MaceBackboneConfig
+from franken.data.base import BaseAtomsDataset, Configuration
+from franken.datasets.registry import DATASET_REGISTRY
+
+
+def test_batched_inference():
+    gnn_cfg = MaceBackboneConfig(path_or_id="mace_mp/small", interaction_block=2)
+    mace_gnn = load_checkpoint(gnn_cfg)
+    
+    data_path = DATASET_REGISTRY.get_path("test", "train", None, False)
+    dataset = BaseAtomsDataset.from_path(
+        data_path=data_path,
+        split="train",
+        gnn_config=gnn_cfg,
+    )
+    data1, data2 = dataset[0], dataset[1]
+    assert isinstance(data1, tuple)
+    assert isinstance(data2, tuple)
+    cfg1 = data1[0]
+    cfg2 = data2[0]
+    cfg1.atom_pos.requires_grad_(True)
+    cfg2.atom_pos.requires_grad_(True)
+    data_concat = Configuration.concatenate([cfg1, cfg2])
+
+    desc_actual = mace_gnn.descriptors(data_concat)
+    desc_expected = torch.cat(
+        [mace_gnn.descriptors(cfg1), mace_gnn.descriptors(cfg2)], dim=0
+    )
+    torch.testing.assert_close(desc_actual, desc_expected, msg="Batched inference values not equal")
+
+    grad_actual = torch.autograd.grad(desc_actual[0].sum(), cfg1.atom_pos, retain_graph=True)
+    grad_expected = torch.autograd.grad(desc_expected[0].sum(), cfg1.atom_pos, retain_graph=True)
+    torch.testing.assert_close(grad_actual, grad_expected, msg="Batched inference gradients (1) not equal")
+    grad_actual = torch.autograd.grad(desc_actual[1].sum(), cfg1.atom_pos)
+    grad_expected = torch.autograd.grad(desc_expected[1].sum(), cfg1.atom_pos)
+    torch.testing.assert_close(grad_actual, grad_expected, msg="Batched inference gradients (2) not equal")
 
 
 def node_attrs_ref_impl(atomic_numbers: torch.Tensor, all_atomic_numbers: torch.Tensor) -> torch.Tensor:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,25 +1,29 @@
 import pytest
 import torch
 
+from franken.metrics.registry import registry
+import franken.metrics as fm
+from franken.data.base import Target, Configuration
+
+ALL_METRICS = [
+    "forces_MAE_species", "forces_RMSE_species", 
+    "energy_MAE", "energy_RMSE", 
+    "forces_MAE", "forces_RMSE", "forces_RMSE2",
+    "forces_cosim"
+]
+
 
 def test_registry_init():
-    from franken.metrics.registry import registry
-
     assert hasattr(registry._instance, "_metrics")
 
 
 def test_available_metrics():
-    import franken.metrics as fm
-
     for name in ["energy_MAE", "forces_MAE", "forces_cosim"]:
         assert name in fm.available_metrics()
 
 
 def test_register():
-    import franken.metrics as fm
-    from franken.metrics.base import BaseMetric
-
-    class MockMetric(BaseMetric):
+    class MockMetric(fm.BaseMetric):
         pass
 
     assert "mock_metric" not in fm.available_metrics()
@@ -28,16 +32,111 @@ def test_register():
 
 
 def test_init_metric():
-    import franken.metrics as fm
-    from franken.metrics.base import BaseMetric
-
-    class MockMetric(BaseMetric):
+    class MockMetric(fm.BaseMetric):
         def __init__(self, device: torch.device, dtype: torch.dtype = torch.float32):
             super().__init__("mock_metric", device, dtype)
 
     fm.register("mock_metric", MockMetric)
     metric = fm.init_metric("mock_metric", torch.device("cpu"))
     assert isinstance(metric, MockMetric)
+
+
+@pytest.mark.parametrize("metric_name", ["forces_MAE_species", "forces_RMSE_species", "energy_MAE", "forces_MAE"])
+class TestShapes:
+    def test_simple(self, metric_name):
+        metric = fm.init_metric(metric_name, torch.device("cpu"))
+        n_atoms = 4
+        data = Configuration(
+            atom_pos=torch.randn(n_atoms, 3),
+            atomic_numbers=torch.randint(0, 40, (n_atoms, )),
+            natoms=torch.tensor(n_atoms)
+        )
+        targets_energy = torch.tensor([1.0])
+        targets_forces = torch.randn(n_atoms, 3)
+        pred_energy = torch.randn(1, 1)
+        pred_forces = torch.randn(1, n_atoms, 3)
+        targets = Target(energy=targets_energy, forces=targets_forces)
+        predictions = Target(energy=pred_energy, forces=pred_forces)
+        metric.update(predictions, targets, data)
+        values = metric.compute()
+        assert values.shape[0] == 1
+
+    def test_missing_model_dim(self, metric_name):
+        metric = fm.init_metric(metric_name, torch.device("cpu"))
+        n_atoms = 4
+        data = Configuration(
+            atom_pos=torch.randn(n_atoms, 3),
+            atomic_numbers=torch.randint(0, 40, (n_atoms, )),
+            natoms=torch.tensor(n_atoms)
+        )
+        targets_energy = torch.tensor([1.0])
+        targets_forces = torch.randn(n_atoms, 3)
+        pred_energy = torch.randn(1)
+        pred_forces = torch.randn(n_atoms, 3)
+        targets = Target(energy=targets_energy, forces=targets_forces)
+        predictions = Target(energy=pred_energy, forces=pred_forces)
+        metric.update(predictions, targets, data)
+        values = metric.compute()
+        assert values.shape[0] == 1  # should default to 1 model
+
+    def test_multimodel(self, metric_name):
+        metric = fm.init_metric(metric_name, torch.device("cpu"))
+        n_atoms = 4
+        n_models = 10
+        data = Configuration(
+            atom_pos=torch.randn(n_atoms, 3),
+            atomic_numbers=torch.randint(0, 40, (n_atoms, )),
+            natoms=torch.tensor(n_atoms)
+        )
+        targets_energy = torch.tensor([1.0])
+        targets_forces = torch.randn(n_atoms, 3)
+        pred_energy = torch.randn(n_models, 1)
+        pred_forces = torch.randn(n_models, n_atoms, 3)
+        targets = Target(energy=targets_energy, forces=targets_forces)
+        predictions = Target(energy=pred_energy, forces=pred_forces)
+        metric.update(predictions, targets, data)
+        values = metric.compute()
+        assert values.shape[0] == n_models
+
+
+@pytest.mark.parametrize("metric_name", ALL_METRICS)
+@pytest.mark.parametrize("n_models", [1, 10])
+def test_batched_configs(metric_name, n_models):
+    metric = fm.init_metric(metric_name, torch.device("cpu"))
+    n_atoms = 4
+    
+    atomic_nums = torch.randint(1, 100, (n_atoms,))
+    cfg1 = Configuration(
+        torch.randn(n_atoms, 3), atomic_nums, torch.tensor(n_atoms)
+    )
+    cfg2 = Configuration(
+        torch.randn(n_atoms, 3), atomic_nums, torch.tensor(n_atoms)
+    )
+    cfg_batched = Configuration.concatenate([cfg1, cfg2])
+    tgt1 = Target(
+        torch.tensor([1.0]), torch.randn(n_atoms, 3)
+    )
+    tgt2 = Target(
+        torch.tensor([2.0]), torch.randn(n_atoms, 3)
+    )
+    tgt_batched = Target(
+        torch.cat([tgt1.energy, tgt2.energy], dim=0), torch.cat([tgt1.forces, tgt2.forces], dim=0)
+    )
+    prd1 = Target(
+        torch.randn(n_models, 1), torch.randn(n_models, n_atoms, 3)
+    )
+    prd2 = Target(
+        torch.randn(n_models, 1), torch.randn(n_models, n_atoms, 3)
+    )
+    prd_batched = Target(
+        torch.cat([prd1.energy, prd2.energy], dim=1), torch.cat([prd1.forces, prd2.forces], dim=1)
+    )
+    metric.update(prd1, tgt1, cfg1)
+    metric.update(prd2, tgt2, cfg2)
+    vals_indiv = metric.compute(reset=True)
+    metric.update(prd_batched, tgt_batched, cfg_batched)
+    vals_batched = metric.compute()
+    torch.testing.assert_close(vals_indiv, vals_batched)
 
 
 @pytest.mark.parametrize(
@@ -47,7 +146,6 @@ def test_init_metric():
         "targets_forces",
         "pred_energy",
         "pred_forces",
-        "atomic_numbers",
         "expected_scalar",
         "expected_entries",
         "expected_shape",
@@ -57,9 +155,8 @@ def test_init_metric():
             "energy_MAE",
             torch.tensor(3.0),
             torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
-            torch.tensor(1.0),
+            torch.tensor([[1.0]]),
             torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
-            None,
             1000.0,
             None,
             None,
@@ -68,9 +165,8 @@ def test_init_metric():
             "energy_RMSE",
             torch.tensor(3.0),
             torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
-            torch.tensor(1.0),
+            torch.tensor([[1.0]]),
             torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
-            None,
             1000.0,
             None,
             None,
@@ -81,7 +177,6 @@ def test_init_metric():
             torch.tensor([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]]),
             torch.tensor(0.0),
             torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
-            None,
             500.0,
             None,
             None,
@@ -92,7 +187,6 @@ def test_init_metric():
             torch.tensor([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]]),
             torch.tensor(0.0),
             torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
-            None,
             ((5.0 / 6.0) ** 0.5) * 1000.0,
             None,
             None,
@@ -103,7 +197,6 @@ def test_init_metric():
             torch.tensor([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]]),
             torch.tensor(0.0),
             torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
-            None,
             ((5.0 / 6.0) ** 0.5) * 1000.0,
             None,
             None,
@@ -114,7 +207,6 @@ def test_init_metric():
             torch.tensor([[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
             torch.tensor(0.0),
             torch.tensor([[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]]),
-            None,
             0.0,
             None,
             None,
@@ -125,7 +217,6 @@ def test_init_metric():
             torch.tensor([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]]),
             torch.tensor(0.0),
             torch.tensor([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
-            torch.tensor([1, 1, 8], dtype=torch.long),
             None,
             [
                 (0, 0, 500.0),
@@ -145,7 +236,6 @@ def test_init_metric():
                     [[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]],
                 ]
             ),
-            torch.tensor([1, 1, 8], dtype=torch.long),
             None,
             [
                 (0, 1, ((1.0 / 3.0) ** 0.5) * 1000.0),
@@ -165,25 +255,27 @@ def test_metric_values_parametrized(
     targets_forces,
     pred_energy,
     pred_forces,
-    atomic_numbers,
     expected_scalar,
     expected_entries,
     expected_shape,
 ):
-    import franken.metrics as fm
-    from franken.data.base import Target
-
     metric = fm.init_metric(metric_name, torch.device("cpu"))
+    n_atoms = targets_forces.shape[0]
+    if "species" in metric_name:
+        atomic_numbers = torch.tensor([1, 1, 8])
+    else:
+        atomic_numbers = torch.randint(0, 40, (n_atoms, ))
+    data = Configuration(
+        atom_pos=torch.randn(n_atoms, 3),
+        atomic_numbers=atomic_numbers,
+        natoms=torch.tensor(n_atoms)
+    )
     targets = Target(energy=targets_energy, forces=targets_forces)
     predictions = Target(energy=pred_energy, forces=pred_forces)
-
-    if atomic_numbers is None:
-        metric.update(predictions, targets)
-    else:
-        assert metric.requires_species
-        metric.update(predictions, targets, atomic_numbers=atomic_numbers)
+    metric.update(predictions, targets, data)
 
     values = metric.compute()
+    print(f"{values=}")
 
     if expected_scalar is not None:
         assert values.item() == pytest.approx(expected_scalar)
@@ -193,15 +285,3 @@ def test_metric_values_parametrized(
         assert expected_entries is not None
         for model_idx, species_idx, expected in expected_entries:
             assert values[model_idx, species_idx].item() == pytest.approx(expected)
-
-
-@pytest.mark.parametrize("metric_name", ["energy_MAE", "energy_RMSE"])
-def test_energy_metrics_require_forces(metric_name):
-    import franken.metrics as fm
-    from franken.data.base import Target
-
-    metric = fm.init_metric(metric_name, torch.device("cpu"))
-    targets = Target(energy=torch.tensor(3.0), forces=None)
-    predictions = Target(energy=torch.tensor(1.0), forces=None)
-    with pytest.raises(NotImplementedError):
-        metric.update(predictions, targets)

--- a/tests/test_pet_wrap.py
+++ b/tests/test_pet_wrap.py
@@ -1,10 +1,12 @@
 
 import torch
+import metatomic.torch
 
 from franken.backbones.utils import load_checkpoint
 from franken.config import PETBackboneConfig
 from franken.data.base import BaseAtomsDataset, Configuration
 from franken.datasets.registry import DATASET_REGISTRY
+from franken.backbones.wrappers.pet_wrap import systems_to_batch
 
 
 def test_batched_inference():
@@ -38,3 +40,80 @@ def test_batched_inference():
     grad_actual = torch.autograd.grad(desc_actual[1].sum(), cfg1.atom_pos)
     grad_expected = torch.autograd.grad(desc_expected[1].sum(), cfg1.atom_pos)
     torch.testing.assert_close(grad_actual, grad_expected, msg="Batched inference gradients (2) not equal")
+
+
+def test_pet_systems_to_batch_accepts_precomputed_cartesian_shifts() -> None:
+    """LLM generated, unclear what's being tested."""
+    positions = torch.tensor(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.8, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+    edge_index = torch.tensor(
+        [[0, 1], [1, 0], [2, 3], [3, 2]],
+        dtype=torch.long,
+    )
+    cell = torch.stack(
+        [
+            torch.eye(3, dtype=torch.float32) * 10.0,
+            torch.eye(3, dtype=torch.float32) * 8.0,
+        ]
+    )
+    unit_shifts = torch.tensor(
+        [[1, 0, 0], [-1, 0, 0], [0, 0, 0], [0, 0, 0]],
+        dtype=torch.long,
+    )
+    batch_ids = torch.tensor([0, 0, 1, 1])
+
+    cartesian_shifts = torch.einsum(
+        "ni,nij->nj", 
+        unit_shifts.to(positions.dtype), 
+        cell[batch_ids[edge_index[:, 0]]]
+    )
+    species = torch.tensor([1, 8, 1, 8], dtype=torch.long)
+
+    species_to_species_index = torch.zeros(9, dtype=torch.long)
+    species_to_species_index[1] = 0
+    species_to_species_index[8] = 1
+
+    nl_options = metatomic.torch.NeighborListOptions(
+        cutoff=6.0,
+        full_list=True,
+        strict=True,
+    )
+
+    out_from_unit = systems_to_batch(
+        positions,
+        edge_index,
+        cell,
+        unit_shifts,
+        species,
+        nl_options,
+        species_to_species_index,
+        cutoff_function="cosine",
+        cutoff_width=0.5,
+        num_neighbors_adaptive=None,
+        cartesian_shifts=None,
+        batch_ids=batch_ids,
+    )
+    out_from_cart = systems_to_batch(
+        positions,
+        edge_index,
+        cell,
+        unit_shifts,
+        species,
+        nl_options,
+        species_to_species_index,
+        cutoff_function="cosine",
+        cutoff_width=0.5,
+        num_neighbors_adaptive=None,
+        cartesian_shifts=cartesian_shifts,
+        batch_ids=batch_ids
+    )
+
+    for a, b in zip(out_from_unit, out_from_cart):
+        torch.testing.assert_close(a, b, rtol=1e-6, atol=1e-6)

--- a/tests/test_pet_wrap.py
+++ b/tests/test_pet_wrap.py
@@ -40,12 +40,14 @@ def test_batched_inference():
     for i in range(desc_actual.shape[0]):
         grad_actual = torch.autograd.grad(desc_actual[i].sum(), cfg1.atom_pos, retain_graph=True)
         grad_expected = torch.autograd.grad(desc_expected[i].sum(), cfg1.atom_pos, retain_graph=True)
-        torch.testing.assert_close(grad_actual, grad_expected, msg=f"Batched inference gradients cfg1, index {i} not equal. {grad_actual=} {grad_expected=}")
+        torch.testing.assert_close(grad_actual, grad_expected, rtol=1e-4, atol=1e-4, 
+            msg=f"Batched inference gradients cfg1, index {i} not equal. {grad_actual=} {grad_expected=}")
         if i >= cfg1.atom_pos.shape[0]:
             torch.testing.assert_close(grad_actual[0].sum().item(), 0.0)
         grad_actual = torch.autograd.grad(desc_actual[i].sum(), cfg2.atom_pos, retain_graph=True)
         grad_expected = torch.autograd.grad(desc_expected[i].sum(), cfg2.atom_pos, retain_graph=True)
-        torch.testing.assert_close(grad_actual, grad_expected, msg=f"Batched inference gradients cfg2, index {i} not equal. {grad_actual=} {grad_expected=}")
+        torch.testing.assert_close(grad_actual, grad_expected, rtol=1e-4, atol=1e-4, 
+            msg=f"Batched inference gradients cfg2, index {i} not equal. {grad_actual=} {grad_expected=}")
         if i < cfg1.atom_pos.shape[0]:
             torch.testing.assert_close(grad_actual[0].sum().item(), 0.0)
 

--- a/tests/test_pet_wrap.py
+++ b/tests/test_pet_wrap.py
@@ -1,4 +1,6 @@
 
+from copy import deepcopy
+
 import torch
 import metatomic.torch
 
@@ -22,6 +24,7 @@ def test_batched_inference():
     data1, data2 = dataset[0], dataset[1]
     assert isinstance(data1, tuple)
     assert isinstance(data2, tuple)
+    # setup data-concat
     cfg1 = data1[0]
     cfg2 = data2[0]
     cfg1.atom_pos.requires_grad_(True)
@@ -33,13 +36,18 @@ def test_batched_inference():
         [pet_gnn.descriptors(cfg1), pet_gnn.descriptors(cfg2)], dim=0
     )
     torch.testing.assert_close(desc_actual, desc_expected, msg="Batched inference values not equal")
-
-    grad_actual = torch.autograd.grad(desc_actual[0].sum(), cfg1.atom_pos, retain_graph=True)
-    grad_expected = torch.autograd.grad(desc_expected[0].sum(), cfg1.atom_pos, retain_graph=True)
-    torch.testing.assert_close(grad_actual, grad_expected, msg="Batched inference gradients (1) not equal")
-    grad_actual = torch.autograd.grad(desc_actual[1].sum(), cfg1.atom_pos)
-    grad_expected = torch.autograd.grad(desc_expected[1].sum(), cfg1.atom_pos)
-    torch.testing.assert_close(grad_actual, grad_expected, msg="Batched inference gradients (2) not equal")
+    
+    for i in range(desc_actual.shape[0]):
+        grad_actual = torch.autograd.grad(desc_actual[i].sum(), cfg1.atom_pos, retain_graph=True)
+        grad_expected = torch.autograd.grad(desc_expected[i].sum(), cfg1.atom_pos, retain_graph=True)
+        torch.testing.assert_close(grad_actual, grad_expected, msg=f"Batched inference gradients cfg1, index {i} not equal. {grad_actual=} {grad_expected=}")
+        if i >= cfg1.atom_pos.shape[0]:
+            torch.testing.assert_close(grad_actual[0].sum().item(), 0.0)
+        grad_actual = torch.autograd.grad(desc_actual[i].sum(), cfg2.atom_pos, retain_graph=True)
+        grad_expected = torch.autograd.grad(desc_expected[i].sum(), cfg2.atom_pos, retain_graph=True)
+        torch.testing.assert_close(grad_actual, grad_expected, msg=f"Batched inference gradients cfg2, index {i} not equal. {grad_actual=} {grad_expected=}")
+        if i < cfg1.atom_pos.shape[0]:
+            torch.testing.assert_close(grad_actual[0].sum().item(), 0.0)
 
 
 def test_pet_systems_to_batch_accepts_precomputed_cartesian_shifts() -> None:

--- a/tests/test_pet_wrap.py
+++ b/tests/test_pet_wrap.py
@@ -1,0 +1,40 @@
+
+import torch
+
+from franken.backbones.utils import load_checkpoint
+from franken.config import PETBackboneConfig
+from franken.data.base import BaseAtomsDataset, Configuration
+from franken.datasets.registry import DATASET_REGISTRY
+
+
+def test_batched_inference():
+    gnn_cfg = PETBackboneConfig(path_or_id="PET_MAD/xs_1.5")
+    pet_gnn = load_checkpoint(gnn_cfg)
+    
+    data_path = DATASET_REGISTRY.get_path("test", "train", None, False)
+    dataset = BaseAtomsDataset.from_path(
+        data_path=data_path,
+        split="train",
+        gnn_config=gnn_cfg,
+    )
+    data1, data2 = dataset[0], dataset[1]
+    assert isinstance(data1, tuple)
+    assert isinstance(data2, tuple)
+    cfg1 = data1[0]
+    cfg2 = data2[0]
+    cfg1.atom_pos.requires_grad_(True)
+    cfg2.atom_pos.requires_grad_(True)
+    data_concat = Configuration.concatenate([cfg1, cfg2])
+
+    desc_actual = pet_gnn.descriptors(data_concat)
+    desc_expected = torch.cat(
+        [pet_gnn.descriptors(cfg1), pet_gnn.descriptors(cfg2)], dim=0
+    )
+    torch.testing.assert_close(desc_actual, desc_expected, msg="Batched inference values not equal")
+
+    grad_actual = torch.autograd.grad(desc_actual[0].sum(), cfg1.atom_pos, retain_graph=True)
+    grad_expected = torch.autograd.grad(desc_expected[0].sum(), cfg1.atom_pos, retain_graph=True)
+    torch.testing.assert_close(grad_actual, grad_expected, msg="Batched inference gradients (1) not equal")
+    grad_actual = torch.autograd.grad(desc_actual[1].sum(), cfg1.atom_pos)
+    grad_expected = torch.autograd.grad(desc_expected[1].sum(), cfg1.atom_pos)
+    torch.testing.assert_close(grad_actual, grad_expected, msg="Batched inference gradients (2) not equal")

--- a/tests/test_rf_heads.py
+++ b/tests/test_rf_heads.py
@@ -128,5 +128,73 @@ class TestEdgeCaseInputs:
                 init_rf(rf_type, input_dim=32, length_scale_low=-1.1)
 
 
+class TestScatterSum:
+    @pytest.mark.parametrize("rf_type", ["poly", "gaussian"])
+    def test_batched_simple(self, rf_type):
+        torch.manual_seed(1)
+        rf = init_rf(
+            rf_type,
+            input_dim=32,
+            num_random_features=128,
+            num_species=None,
+            chemically_informed_ratio=None,
+        )
+        dt = torch.float32
+        data = torch.randn(10, 32, dtype=dt)
+        atomic_nums = torch.tensor([0, 1, 2, 3, 0, 0, 1, 2, 3, 0]).long()
+
+        batch_ids = torch.cat([torch.zeros(5), torch.ones(5)]).long()
+        fmap_batched = rf.feature_map(data, atomic_numbers=atomic_nums, batch_ids=batch_ids)
+        fmap_single = torch.cat([
+            rf.feature_map(data[:5], atomic_numbers=atomic_nums[:5]),
+            rf.feature_map(data[5:], atomic_numbers=atomic_nums[5:])
+        ])
+        torch.testing.assert_close(fmap_batched, fmap_single)
+
+    @pytest.mark.parametrize("rf_type", ["poly", "gaussian"])
+    def test_batched_perspecies(self, rf_type):
+        torch.manual_seed(1)
+        rf = init_rf(
+            rf_type,
+            input_dim=8,
+            num_random_features=4,
+            num_species=4,
+            chemically_informed_ratio=None,
+        )
+        dt = torch.float32
+        data = torch.randn(10, 8, dtype=dt)
+        atomic_nums = torch.tensor([0, 1, 2, 3, 0, 0, 1, 2, 3, 0]).long()
+
+        batch_ids = torch.cat([torch.zeros(5), torch.ones(5)]).long()
+        fmap_batched = rf.feature_map(data, atomic_numbers=atomic_nums, batch_ids=batch_ids)
+        fmap_single = torch.cat([
+            rf.feature_map(data[:5], atomic_numbers=atomic_nums[:5]),
+            rf.feature_map(data[5:], atomic_numbers=atomic_nums[5:])
+        ])
+        torch.testing.assert_close(fmap_batched, fmap_single)
+
+    @pytest.mark.parametrize("rf_type", ["poly", "gaussian"])
+    def test_batched_chemratio(self, rf_type):
+        torch.manual_seed(1)
+        rf = init_rf(
+            rf_type,
+            input_dim=32,
+            num_random_features=128,
+            num_species=4,
+            chemically_informed_ratio=0.2,
+        )
+        dt = torch.float32
+        data = torch.randn(10, 32, dtype=dt)
+        atomic_nums = torch.tensor([0, 1, 2, 3, 0, 0, 1, 2, 3, 0]).long()
+
+        batch_ids = torch.cat([torch.zeros(5), torch.ones(5)]).long()
+        fmap_batched = rf.feature_map(data, atomic_numbers=atomic_nums, batch_ids=batch_ids)
+        fmap_single = torch.cat([
+            rf.feature_map(data[:5], atomic_numbers=atomic_nums[:5]),
+            rf.feature_map(data[5:], atomic_numbers=atomic_nums[5:])
+        ])
+        torch.testing.assert_close(fmap_batched, fmap_single)
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_torchsim_inf_wrap.py
+++ b/tests/test_torchsim_inf_wrap.py
@@ -1,0 +1,256 @@
+import traceback
+
+import pytest
+import torch
+
+from franken.backbones.wrappers.pet_wrap import systems_to_batch
+from franken.calculators.torchsim_inf_wrap import FrankenTorchSimModel
+from franken.config import GaussianRFConfig, MaceBackboneConfig, PETBackboneConfig
+from franken.data.base import Configuration
+from franken.rf.model import FrankenPotential
+from tests.utils import mocked_gnn
+
+
+try:
+    import metatomic.torch
+    import torch_sim as ts
+    from ase.build import molecule
+    from torch_sim.models.interface import validate_model_outputs
+except ImportError:
+    pytest.skip(
+        f"torch-sim/metatomic not installed: {traceback.format_exc()}",
+        allow_module_level=True,
+    )
+
+
+def _build_mock_franken_model(
+    family: str = "mace",
+    *,
+    device: str | torch.device = "cpu",
+) -> FrankenPotential:
+    if family == "mace":
+        gnn_cfg = MaceBackboneConfig("mace_mp/small")
+    elif family == "pet":
+        gnn_cfg = PETBackboneConfig("PET_OMat/xs_1.0")
+    else:
+        raise ValueError(family)
+
+    rf_cfg = GaussianRFConfig(num_random_features=16, length_scale=1.0)
+    with mocked_gnn(device=device, dtype=torch.float32, feature_dim=12):
+        model = FrankenPotential(
+            gnn_config=gnn_cfg,
+            rf_config=rf_cfg,
+            scale_by_Z=False,
+            num_species=1,
+        )
+    return model.to(device=device, dtype=torch.float32)
+
+
+def _demo_state(dtype: torch.dtype = torch.float32) -> ts.SimState:
+    h2o = molecule("H2O")
+    h2o.center(vacuum=5.0)
+    ch4 = molecule("CH4")
+    ch4.center(vacuum=5.0)
+    return ts.io.atoms_to_state([h2o, ch4], device=torch.device("cpu"), dtype=dtype)
+
+
+def test_batched_energy_force_matches_single_system_calls() -> None:
+    model = _build_mock_franken_model("mace")
+
+    atom_pos = torch.randn(6, 3, dtype=torch.float32)
+    atomic_numbers = torch.tensor([1, 8, 1, 6, 1, 8], dtype=torch.int64)
+    batch_ids = torch.tensor([0, 0, 1, 1, 1, 1], dtype=torch.long)
+    natoms = torch.bincount(batch_ids, minlength=2).to(dtype=torch.int64)
+    batched = Configuration(
+        atom_pos=atom_pos,
+        atomic_numbers=atomic_numbers,
+        natoms=natoms,
+        batch_ids=batch_ids,
+    )
+
+    fmap = model.feature_map_batched(batched)
+    assert fmap.shape[0] == 2
+
+    energy_b, forces_b = model.energy_and_forces_batched(batched)
+    assert forces_b is not None
+
+    single_energies = []
+    single_forces = []
+    for sid in range(2):
+        mask = batch_ids == sid
+        single = Configuration(
+            atom_pos=atom_pos[mask].clone(),
+            atomic_numbers=atomic_numbers[mask].clone(),
+            natoms=torch.tensor([int(mask.sum())], dtype=torch.int64),
+        )
+        e, f = model.energy_and_forces(single)
+        assert f is not None
+        single_energies.append(e.reshape(-1)[0])
+        single_forces.append(f.reshape(-1, 3))
+
+    torch.testing.assert_close(
+        energy_b,
+        torch.stack(single_energies),
+        rtol=1e-5,
+        atol=1e-5,
+    )
+    torch.testing.assert_close(
+        forces_b,
+        torch.cat(single_forces, dim=0),
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+
+def test_torchsim_adapter_forward_shapes_detached_and_no_state_mutation() -> None:
+    model = _build_mock_franken_model("mace")
+    adapter = FrankenTorchSimModel(model, device="cpu", dtype=torch.float32)
+
+    state = _demo_state(torch.float32)
+    pos0 = state.positions.clone()
+    cell0 = state.cell.clone()
+    sys0 = state.system_idx.clone()
+    z0 = state.atomic_numbers.clone()
+
+    out = adapter(state)
+    assert set(out.keys()) == {"energy", "forces"}
+    assert out["energy"].shape == (state.n_systems,)
+    assert out["forces"].shape == state.positions.shape
+    assert not out["energy"].requires_grad
+    assert not out["forces"].requires_grad
+
+    torch.testing.assert_close(state.positions, pos0)
+    torch.testing.assert_close(state.cell, cell0)
+    torch.testing.assert_close(state.system_idx, sys0)
+    torch.testing.assert_close(state.atomic_numbers, z0)
+
+
+def test_torchsim_adapter_supports_mace_and_pet_families() -> None:
+    state = _demo_state(torch.float32)
+
+    mace_model = _build_mock_franken_model("mace")
+    pet_model = _build_mock_franken_model("pet")
+
+    mace_adapter = FrankenTorchSimModel(mace_model, device="cpu", dtype=torch.float32)
+    pet_adapter = FrankenTorchSimModel(pet_model, device="cpu", dtype=torch.float32)
+
+    out_mace = mace_adapter(state)
+    out_pet = pet_adapter(state)
+
+    assert out_mace["energy"].shape == (state.n_systems,)
+    assert out_pet["energy"].shape == (state.n_systems,)
+
+
+def test_torchsim_adapter_construction_from_checkpoint_path(tmp_path) -> None:
+    model = _build_mock_franken_model("mace")
+    ckpt_path = tmp_path / "franken_mock.pt"
+    model.save(ckpt_path)
+
+    with mocked_gnn(device="cpu", dtype=torch.float32, feature_dim=12):
+        adapter = FrankenTorchSimModel(ckpt_path, device="cpu", dtype=torch.float32)
+
+    out = adapter(_demo_state(torch.float32))
+    assert out["energy"].ndim == 1
+    assert out["forces"].ndim == 2
+
+
+def test_torchsim_model_interface_contract() -> None:
+    model = _build_mock_franken_model("mace")
+    adapter = FrankenTorchSimModel(model, device=torch.device("cpu"), dtype=torch.float32)
+    validate_model_outputs(
+        adapter,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+        check_detached=True,
+    )
+
+
+def test_pet_systems_to_batch_accepts_precomputed_cartesian_shifts() -> None:
+    positions = torch.tensor(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.8, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+    edge_index = torch.tensor(
+        [[0, 1], [1, 0], [2, 3], [3, 2]],
+        dtype=torch.long,
+    )
+    cell = torch.stack(
+        [
+            torch.eye(3, dtype=torch.float32) * 10.0,
+            torch.eye(3, dtype=torch.float32) * 8.0,
+        ]
+    )
+    unit_shifts = torch.tensor(
+        [[1, 0, 0], [-1, 0, 0], [0, 0, 0], [0, 0, 0]],
+        dtype=torch.long,
+    )
+    edge_system_idx = torch.tensor([0, 0, 1, 1], dtype=torch.long)
+    cartesian_shifts = torch.einsum(
+        "ni,nij->nj",
+        unit_shifts.to(cell.dtype),
+        cell[edge_system_idx],
+    )
+    species = torch.tensor([1, 8, 1, 8], dtype=torch.long)
+
+    species_to_species_index = torch.zeros(9, dtype=torch.long)
+    species_to_species_index[1] = 0
+    species_to_species_index[8] = 1
+
+    nl_options = metatomic.torch.NeighborListOptions(
+        cutoff=6.0,
+        full_list=True,
+        strict=True,
+    )
+
+    out_from_unit = systems_to_batch(
+        positions,
+        edge_index,
+        cell,
+        unit_shifts,
+        species,
+        nl_options,
+        species_to_species_index,
+        cutoff_function="cosine",
+        cutoff_width=0.5,
+        num_neighbors_adaptive=None,
+        cartesian_shifts=None,
+        edge_system_idx=edge_system_idx,
+    )
+    out_from_cart = systems_to_batch(
+        positions,
+        edge_index,
+        cell,
+        unit_shifts,
+        species,
+        nl_options,
+        species_to_species_index,
+        cutoff_function="cosine",
+        cutoff_width=0.5,
+        num_neighbors_adaptive=None,
+        cartesian_shifts=cartesian_shifts,
+        edge_system_idx=edge_system_idx,
+    )
+
+    for a, b in zip(out_from_unit, out_from_cart):
+        torch.testing.assert_close(a, b, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_torchsim_adapter_cuda_batched_smoke() -> None:
+    model = _build_mock_franken_model("mace", device="cuda")
+    adapter = FrankenTorchSimModel(model, device="cuda", dtype=torch.float32)
+
+    state = _demo_state(torch.float32).to(device=torch.device("cuda"), dtype=torch.float32)
+    out = adapter(state)
+
+    assert out["energy"].shape == (state.n_systems,)
+    assert out["forces"].shape == state.positions.shape
+    assert out["energy"].device.type == "cuda"
+    assert out["forces"].device.type == "cuda"
+    assert not out["energy"].requires_grad
+    assert not out["forces"].requires_grad

--- a/tests/test_torchsim_inf_wrap.py
+++ b/tests/test_torchsim_inf_wrap.py
@@ -2,8 +2,8 @@ import traceback
 
 import pytest
 import torch
+from ase.build import molecule
 
-from franken.backbones.wrappers.pet_wrap import systems_to_batch
 from franken.calculators.torchsim_inf_wrap import FrankenTorchSimModel
 from franken.config import GaussianRFConfig, MaceBackboneConfig, PETBackboneConfig
 from franken.data.base import Configuration
@@ -12,9 +12,7 @@ from tests.utils import mocked_gnn
 
 
 try:
-    import metatomic.torch
     import torch_sim as ts
-    from ase.build import molecule
     from torch_sim.models.interface import validate_model_outputs
 except ImportError:
     pytest.skip(
@@ -68,10 +66,7 @@ def test_batched_energy_force_matches_single_system_calls() -> None:
         batch_ids=batch_ids,
     )
 
-    fmap = model.feature_map_batched(batched)
-    assert fmap.shape[0] == 2
-
-    energy_b, forces_b = model.energy_and_forces_batched(batched)
+    energy_b, forces_b = model.energy_and_forces(batched)
     assert forces_b is not None
 
     single_energies = []
@@ -85,18 +80,17 @@ def test_batched_energy_force_matches_single_system_calls() -> None:
         )
         e, f = model.energy_and_forces(single)
         assert f is not None
-        single_energies.append(e.reshape(-1)[0])
-        single_forces.append(f.reshape(-1, 3))
-
+        single_energies.append(e)
+        single_forces.append(f)
     torch.testing.assert_close(
         energy_b,
-        torch.stack(single_energies),
+        torch.cat(single_energies, dim=1),
         rtol=1e-5,
         atol=1e-5,
     )
     torch.testing.assert_close(
         forces_b,
-        torch.cat(single_forces, dim=0),
+        torch.cat(single_forces, dim=1),
         rtol=1e-5,
         atol=1e-5,
     )
@@ -161,83 +155,7 @@ def test_torchsim_model_interface_contract() -> None:
         adapter,
         device=torch.device("cpu"),
         dtype=torch.float32,
-        check_detached=True,
     )
-
-
-def test_pet_systems_to_batch_accepts_precomputed_cartesian_shifts() -> None:
-    positions = torch.tensor(
-        [
-            [0.0, 0.0, 0.0],
-            [1.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0],
-            [0.8, 0.0, 0.0],
-        ],
-        dtype=torch.float32,
-    )
-    edge_index = torch.tensor(
-        [[0, 1], [1, 0], [2, 3], [3, 2]],
-        dtype=torch.long,
-    )
-    cell = torch.stack(
-        [
-            torch.eye(3, dtype=torch.float32) * 10.0,
-            torch.eye(3, dtype=torch.float32) * 8.0,
-        ]
-    )
-    unit_shifts = torch.tensor(
-        [[1, 0, 0], [-1, 0, 0], [0, 0, 0], [0, 0, 0]],
-        dtype=torch.long,
-    )
-    edge_system_idx = torch.tensor([0, 0, 1, 1], dtype=torch.long)
-    cartesian_shifts = torch.einsum(
-        "ni,nij->nj",
-        unit_shifts.to(cell.dtype),
-        cell[edge_system_idx],
-    )
-    species = torch.tensor([1, 8, 1, 8], dtype=torch.long)
-
-    species_to_species_index = torch.zeros(9, dtype=torch.long)
-    species_to_species_index[1] = 0
-    species_to_species_index[8] = 1
-
-    nl_options = metatomic.torch.NeighborListOptions(
-        cutoff=6.0,
-        full_list=True,
-        strict=True,
-    )
-
-    out_from_unit = systems_to_batch(
-        positions,
-        edge_index,
-        cell,
-        unit_shifts,
-        species,
-        nl_options,
-        species_to_species_index,
-        cutoff_function="cosine",
-        cutoff_width=0.5,
-        num_neighbors_adaptive=None,
-        cartesian_shifts=None,
-        edge_system_idx=edge_system_idx,
-    )
-    out_from_cart = systems_to_batch(
-        positions,
-        edge_index,
-        cell,
-        unit_shifts,
-        species,
-        nl_options,
-        species_to_species_index,
-        cutoff_function="cosine",
-        cutoff_width=0.5,
-        num_neighbors_adaptive=None,
-        cartesian_shifts=cartesian_shifts,
-        edge_system_idx=edge_system_idx,
-    )
-
-    for a, b in zip(out_from_unit, out_from_cart):
-        torch.testing.assert_close(a, b, rtol=1e-6, atol=1e-6)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/tests/test_transfer_perf/leo_launch.sh
+++ b/tests/test_transfer_perf/leo_launch.sh
@@ -11,8 +11,8 @@
 
 . ~/.bashrc
 
-micromamba activate franken-dev
+micromamba activate franken12
 cd ~/franken
 
 export PYTHONUNBUFFERED=1
-PYTHONPATH='.' python tests/test_transfer_perf/test_water.py --db-path=tests/test_transfer_perf/results_2703.pkl
+PYTHONPATH='.' python tests/test_transfer_perf/test_water.py --db-path=tests/test_transfer_perf/results_1404.pkl

--- a/tests/test_transfer_perf/plot.py
+++ b/tests/test_transfer_perf/plot.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.patches import Patch
@@ -5,9 +7,16 @@ import pandas as pd
 import pickle
 
 
-def plots(file_name):
+def plots(file_name, save: bool):
     with open(file_name, "rb") as fh:
         data = pickle.load(fh)
+    for d in data:
+        for j in [1, 2, 4, 16, 64, 128]:
+            key = f"results_ts_time_per_atom_{j}"
+            if key not in d:
+                continue
+            if isinstance(d[key], tuple):
+                d[key] = d[key][0]
     df = pd.DataFrame(data)
 
     # Make sure no duplicates exist
@@ -17,39 +26,54 @@ def plots(file_name):
             "Multiple rows found for some (gnn_path_or_id, compile) pairs:\n"
             f"{counts[counts > 1]}"
         )
+    # Check whether to plot the torch-sim experiment
+    plot_torchsim = True
+    if "results_ts_time_per_atom_1" not in df.columns:
+        plot_torchsim = False
     # Note: aggregation is fake, we don't allow duplicates
+    agg_lbls = {
+        'gnn_family': 'first',
+        'results_train_time': 'mean',
+        'results_md_time_per_atom': 'mean',
+        'results_forces_MAE': 'mean',
+        'results_md_stable': 'all',
+    }
+    if plot_torchsim:
+        agg_lbls |= {
+            'results_ts_time_per_atom_1': 'mean',
+            'results_ts_time_per_atom_2': 'mean',
+            'results_ts_time_per_atom_4': 'mean',
+            'results_ts_time_per_atom_16': 'mean',
+            'results_ts_time_per_atom_64': 'mean',
+            'results_ts_time_per_atom_128': 'mean',
+        }
     agg_df = (
         df.groupby(['gnn_path_or_id', 'compile'], as_index=False)
-        .agg({
-            'gnn_family': 'first',
-            'results_train_time': 'mean',
-            'results_md_time_per_atom': 'mean',
-            'results_forces_MAE': 'mean',
-            'results_md_stable': 'all',
-        })
+        .agg(agg_lbls)
         .sort_values(['gnn_family', 'gnn_path_or_id'])
     )
 
-    fig, ax = plt.subplots(ncols=1, nrows=3, figsize=(6, 8))
+    fig, ax = plt.subplots(ncols=2, nrows=3, figsize=(12, 8))
     plot_grouped_bar(
         agg_df,
         value_col='results_train_time',
         title='Training Time per GNN',
-        ylabel='Time',
+        ylabel='Time (s)',
         x_ticks=False,
         affects_compile=False,
-        figax=(fig, ax[0]),
+        figax=(fig, ax[0, 0]),
     )
     plot_grouped_bar(
         agg_df,
         value_col='results_md_time_per_atom',
         title='MD Time per Atom per GNN',
-        ylabel='Time per atom',
+        ylabel='Time per atom (s)',
         x_ticks=False,
         affects_compile=True,
         stability_col="results_md_stable",
-        figax=(fig, ax[1]),
+        figax=(fig, ax[1, 0]),
     )
+    ax[1, 0].set_yscale('log', base=2)
     plot_grouped_bar(
         agg_df,
         value_col='results_forces_MAE',
@@ -57,10 +81,53 @@ def plots(file_name):
         ylabel='MAE',
         x_ticks=True,
         affects_compile=False,
-        figax=(fig, ax[2]),
+        figax=(fig, ax[2, 0]),
     )
+    if plot_torchsim:
+        plot_throughput(
+            agg_df,
+            col_prefix="results_ts_time_per_atom", 
+            lw=2,
+            figax=(fig, ax[0, 1]),
+        )
+        ax[0, 1].set_title("Torch-Sim throughput")
+    else:
+        ax[0, 1].axis('off')
+    ax[1, 1].axis('off')
+    ax[2, 1].axis('off')
     fig.tight_layout()
+    if save:
+        save_path = Path(file_name).with_suffix(".png")
+        fig.savefig(save_path, bbox_inches="tight")
+        print(f"Saved plot to {save_path}")
     plt.show()
+
+
+def plot_throughput(df, col_prefix="", family_col="gnn_family", lw=1, figax=None):
+    if figax is None:
+        fig, ax = plt.subplots(figsize=(10, 5))
+    else:
+        fig, ax = figax
+    families = df[family_col].unique()
+    cmap = plt.get_cmap('tab10')
+    linestyles = ["solid", "dotted", "dashed", "dashdot"]
+    family_to_ls = {
+        fam: linestyles[i] for i, fam in enumerate(families)
+    }
+    x = sorted([int(c.split("_")[-1]) for c in df.columns if c.startswith(col_prefix)])
+
+    for fam, subdf in df.groupby(family_col):
+        gnn_ids = sorted(subdf['gnn_path_or_id'].unique())
+        for i, g in enumerate(gnn_ids):
+            subset = subdf[subdf['gnn_path_or_id'] == g]
+            y = [subset[f"{col_prefix}_{x_val}"].mean() for x_val in x]
+            ax.plot(x, y, ls=family_to_ls[fam], c=cmap(i % 10), label=g, marker='o', lw=lw)
+    ax.legend(bbox_to_anchor=(0.5, -0.3))
+    ax.set_xlabel("Batch size")
+    ax.set_ylabel("Time per atom (s)")
+    ax.set_xscale('log', base=2)
+    ax.set_yscale('log', base=2)
+    return fig, ax
 
 
 def plot_grouped_bar(
@@ -192,8 +259,13 @@ def plot_grouped_bar(
     ]
     
     ax.legend(handles=compile_legend + family_legend, loc="best")
-    
     return fig, ax
 
 if __name__ == "__main__":
-    plots("results_2703.pkl")
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--path', type=str, help="Path to database")
+    parser.add_argument('-s', '--save', action="store_true", help="Save output plot")
+    args = parser.parse_args()
+    plots(args.path, args.save)
+

--- a/tests/test_transfer_perf/test_water.py
+++ b/tests/test_transfer_perf/test_water.py
@@ -30,6 +30,7 @@ from franken.data.base import Configuration
 from franken.datasets.registry import DATASET_REGISTRY
 from franken.backbones.utils import CacheDir
 from franken.rf.model import FrankenPotential
+from franken.utils.misc import is_cuda_out_of_memory
 
 
 def train_eval_franken(
@@ -179,12 +180,15 @@ def batched_throughput_torchsim(
                 _ = ts_wrap(batch_tsstate)
                 torch.cuda.synchronize()
                 t_e = time.time()
-                if i > 3:  # warmup for time collection
+                if i > warmup_steps:  # warmup for time collection
                     times.append(t_e - t_s)
             ts_info[f"ts_time_per_atom_{batch_size}"] = float(np.mean(times) / len(atoms) / batch_size),
-        except Exception:
+        except Exception as e:
             ts_info[f"ts_time_per_atom_{batch_size}"] = np.nan
-            ts_info[f"ts_exception_{batch_size}"] = traceback.format_exc()
+            if is_cuda_out_of_memory(e):
+                ts_info[f"ts_exception_{batch_size}"] = "OOM"
+            else:
+                ts_info[f"ts_exception_{batch_size}"] = traceback.format_exc()
     return ts_info
 
 
@@ -297,7 +301,7 @@ def run(db_path):
     ts_options = {
         "num_steps": 100,
         "warmup_steps": 10,
-        "batch_sizes": [4, 16, 64, 256],
+        "batch_sizes": [1, 2, 4, 16, 64, 128],
     }
     md_data = get_md_data(**md_data_info)  
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")

--- a/tests/test_transfer_perf/test_water.py
+++ b/tests/test_transfer_perf/test_water.py
@@ -19,12 +19,14 @@ import torch
 
 from franken.autotune import autotune
 from franken.calculators.ase_calc import FrankenCalculator
+from franken.calculators.torchsim_inf_wrap import FrankenTorchSimModel
 from franken.config import (
     BackboneConfig, DatasetConfig, 
     MultiscaleGaussianRFConfig, SolverConfig, HPSearchConfig, 
     AutotuneConfig
 )
 from franken.backbones.wrappers.common_patches import unpatch_e3nn
+from franken.data.base import Configuration
 from franken.datasets.registry import DATASET_REGISTRY
 from franken.backbones.utils import CacheDir
 from franken.rf.model import FrankenPotential
@@ -130,6 +132,62 @@ def get_md_data(data_type: Literal["water", "diamond"], **kwargs) -> ase.Atoms:
     return atoms
 
 
+def batched_throughput_torchsim(
+    model: FrankenPotential, 
+    atoms: ase.Atoms, 
+    batch_sizes: Sequence[int],
+    device,
+    num_steps: int,
+    warmup_steps: int,
+):
+    # Test the througput of torch-sim batched model
+    import torch_sim.state
+    if warmup_steps >= num_steps:
+        raise ValueError("warmup steps invalid")
+    
+    # Create batched torch-sim state (replicate atoms `batch_size` times)
+    cell = torch.zeros((3, 3), dtype=torch.float32, device=device)
+    pbc = torch.tensor(atoms.get_pbc(), dtype=torch.bool, device=device)
+    cell[pbc] = torch.tensor(atoms.get_cell()[atoms.get_pbc()], dtype=torch.float32, device=device) # type: ignore
+    one_cfg = Configuration(
+        atom_pos=torch.tensor(atoms.get_positions(), dtype=torch.float32, device=device),
+        atomic_numbers=torch.tensor(atoms.get_atomic_numbers(), device=device, dtype=torch.int32),
+        natoms=torch.tensor(len(atoms), device=device, dtype=torch.int32),
+        cell=cell,
+        batch_ids=torch.zeros(atoms.get_positions().shape[0], dtype=torch.int32, device=device),
+        pbc=pbc,
+    )
+    ts_info = {}
+    for batch_size in batch_sizes:
+        try:
+            batch_cfg = Configuration.concatenate([deepcopy(one_cfg) for _ in range(batch_size)])
+            assert batch_cfg.cell is not None and batch_cfg.pbc is not None
+            batch_tsstate = torch_sim.state.SimState(
+                positions=batch_cfg.atom_pos,
+                masses=torch.ones_like(batch_cfg.atom_pos),
+                cell=batch_cfg.cell,
+                pbc=batch_cfg.pbc,
+                atomic_numbers=batch_cfg.atomic_numbers,
+                system_idx=batch_cfg.batch_ids,
+            )
+            # Wrap the franken model into torch-sim
+            ts_wrap = FrankenTorchSimModel(model, device=device, dtype=torch.float32)
+            times = []
+            torch.cuda.synchronize()
+            for i in range(num_steps):
+                t_s = time.time()
+                _ = ts_wrap(batch_tsstate)
+                torch.cuda.synchronize()
+                t_e = time.time()
+                if i > 3:  # warmup for time collection
+                    times.append(t_e - t_s)
+            ts_info[f"ts_time_per_atom_{batch_size}"] = float(np.mean(times) / len(atoms) / batch_size),
+        except Exception:
+            ts_info[f"ts_time_per_atom_{batch_size}"] = np.nan
+            ts_info[f"ts_exception_{batch_size}"] = traceback.format_exc()
+    return ts_info
+
+
 def molecular_dynamics_ase(
     model: FrankenPotential, 
     atoms: ase.Atoms, 
@@ -217,6 +275,9 @@ def logtime():
 
 
 def run(db_path):
+    """
+
+    """
     # 0. Options
     md_data_info = {
         "data_type": "water",
@@ -232,6 +293,11 @@ def run(db_path):
         "n_rf": 8192,
         "seed": 1,
         "dset": "water",
+    }
+    ts_options = {
+        "num_steps": 100,
+        "warmup_steps": 10,
+        "batch_sizes": [4, 16, 64, 256],
     }
     md_data = get_md_data(**md_data_info)  
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
@@ -328,6 +394,7 @@ def run(db_path):
                 **add_prefix(gnn_ckpt, "gnn"),
                 **add_prefix(md_data_info, "md_data"),
                 **add_prefix(md_options, "md"),
+                **add_prefix(ts_options, "ts"),
                 **add_prefix(train_options, "train"),
             }
             if check_db_has_config(db, key_info):
@@ -343,6 +410,7 @@ def run(db_path):
                     gnn_config=gnn_config,
                     **train_options
                 )
+
             try:
                 # 2. Define preprocessing steps for the franken-potential e.g. compile
                 if compile == "jit":
@@ -357,20 +425,36 @@ def run(db_path):
                     franken_model_comp = torch.compile(franken_model)
                 else:
                     franken_model_comp = franken_model
-                print(f"[{logtime()}] starting MD for {gnn_config.path_or_id}")
-                torch.manual_seed(md_options["seed"])
-                np.random.seed(md_options["seed"])
-                md_info = molecular_dynamics_ase(
-                    franken_model_comp, deepcopy(md_data), gnn_config=gnn_config, device=device, **md_options
-                )
             except Exception as e:
-                md_info = {
-                    "exception": traceback.format_exc(),
-                    "md_stable": False,
-                    "md_iterations": 0,
-                    "md_time_per_atom": 0,
-                }
-            results_info = add_prefix(md_info | train_info, "results")
+                print(f"[{logtime()}] failed to compile {gnn_config.path_or_id} with option '{compile}'")
+                franken_model_comp = None
+                md_info = {}
+                ts_info = {}
+            else:
+                try:
+                    # 3. Run molecular dynamics
+                    print(f"[{logtime()}] starting MD for {gnn_config.path_or_id}")
+                    torch.manual_seed(md_options["seed"])
+                    np.random.seed(md_options["seed"])
+                    md_info = molecular_dynamics_ase(
+                        franken_model_comp, deepcopy(md_data), gnn_config=gnn_config, device=device, **md_options
+                    )
+                except Exception:
+                    md_info = {
+                        "md_exception": traceback.format_exc(),
+                        "md_stable": False,
+                        "md_iterations": 0,
+                        "md_time_per_atom": 0,
+                    }
+                # 4. Run batched throughput
+                ts_info = batched_throughput_torchsim(
+                    model=franken_model_comp,
+                    atoms=deepcopy(md_data),
+                    device=device,
+                    **ts_options
+                )
+            # End. Log results
+            results_info = add_prefix(md_info | train_info | ts_info, "results")
             all_info = key_info | results_info # type: ignore
             db.append(all_info)
             with open(db_path, "wb") as fh:

--- a/tests/test_transfer_perf/test_water.py
+++ b/tests/test_transfer_perf/test_water.py
@@ -182,8 +182,10 @@ def batched_throughput_torchsim(
                 t_e = time.time()
                 if i > warmup_steps:  # warmup for time collection
                     times.append(t_e - t_s)
-            ts_info[f"ts_time_per_atom_{batch_size}"] = float(np.mean(times) / len(atoms) / batch_size),
+            ts_info[f"ts_time_per_atom_{batch_size}"] = float(np.mean(times) / len(atoms) / batch_size)
         except Exception as e:
+            print(f"[{logtime()}] TorchSim error at batch size {batch_size}:")
+            print(e)
             ts_info[f"ts_time_per_atom_{batch_size}"] = np.nan
             if is_cuda_out_of_memory(e):
                 ts_info[f"ts_exception_{batch_size}"] = "OOM"
@@ -451,6 +453,7 @@ def run(db_path):
                         "md_time_per_atom": 0,
                     }
                 # 4. Run batched throughput
+                print(f"[{logtime()}] starting TorchSim throughput test for {gnn_config.path_or_id}")
                 ts_info = batched_throughput_torchsim(
                     model=franken_model_comp,
                     atoms=deepcopy(md_data),
@@ -464,7 +467,7 @@ def run(db_path):
             with open(db_path, "wb") as fh:
                 pickle.dump(db, fh)
                 fh.flush()
-            print(f"[{logtime()}] Finished experiment MD...")
+            print(f"[{logtime()}] Finished experiments...")
             print(all_info)
             print()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,6 +46,14 @@ def mocked_gnn(device, dtype, feature_dim: int = 32, backbone_id: str = "test"):
     # A bunch of code to initialize a mock for the GNN
     gnn = MagicMock()
     gnn.feature_dim = MagicMock(return_value=feature_dim)
+    gnn.cutoff_radius = MagicMock(return_value=6.0)
+    gnn.num_interaction_layers = MagicMock(return_value=2)
+    gnn.supported_atomic_types = MagicMock(
+        return_value=torch.tensor([1, 6, 8], dtype=torch.int64)
+    )
+    gnn.franken_train = MagicMock(return_value=None)
+    gnn.franken_val = MagicMock(return_value=None)
+
     fake_gnn_weight = torch.randn(3, feature_dim, device=device, dtype=dtype)
 
     def mock_descriptors(data):


### PR DESCRIPTION
## Summary
- add `FrankenTorchSimModel` in `franken/calculators/torchsim_inf_wrap.py` implementing `torch_sim.models.interface.ModelInterface`
- integrate batched multi-system inference path in Franken core:
  - `feature_map_batched(...)`
  - `energy_batched(...)`
  - `energy_and_forces_batched(...)`
- extend RF pooling and atomic energy shift logic for per-system reductions via `batch_ids`
- update PET wrapper path to accept precomputed Cartesian shifts in batched mode while preserving single-system behavior
- add torch-sim integration tests covering interface contract, batching consistency, checkpoint loading, non-mutation, detached outputs, and CUDA smoke (when available)

## Rationale
The objective is to develop an interface to make Franken usable in torch-sim.

Key design choices:
- **Single batched pass over all systems** instead of Python per-system loops, to reduce overhead and improve GPU utilization.
- **Strict interface contract** with torch-sim (`SimState` in, `energy`/`forces` out) so it composes with torch-sim workflows.
- **Scoped v1 support** (MACE/PET, energy+forces, no stress) to keep behavior explicit and testable.
- **Compatibility-preserving PET update** so batched shift handling works without breaking existing single-system behavior.

## Behavior contract
- input: torch-sim `SimState`
- output:
  - `energy`: shape `[n_systems]`
  - `forces`: shape `[n_atoms, 3]`
- outputs are detached
- input `SimState` is not mutated in place

## Validation
- `pytest -q tests/test_torchsim_inf_wrap.py` -> pass
- `pytest -q tests/test_FrankenPotential.py -k test_gradients_mocked` -> pass
- `python -m py_compile` on modified integration files -> pass
