### PR TITLE
Added functionality to allow passing manual atomic energies for training

### DIFF
--- a/franken/autotune/cli.py
+++ b/franken/autotune/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import ast
 import dataclasses
 import types
 import typing
@@ -72,6 +73,19 @@ def field_is_optional_literal(field_type: Any):
     is_lit_present = typing.Literal in all_subtype_origins
     return is_lit_present and len(all_subtypes) == 2
 
+
+def parse_atomic_energies(s: str) -> dict[int, float] | None:
+    if s.lower() == "none":
+        return None
+
+    parsed = ast.literal_eval(s)
+    if not isinstance(parsed, dict):
+        raise TypeError("atomic energies must be a dictionary")
+
+    atomic_energies = {}
+    for key, value in parsed.items():
+        atomic_energies[int(key)] = float(value)
+    return atomic_energies
 
 def parse_union_type(*parsers):
     def union_parser(f: Any):
@@ -561,6 +575,12 @@ def build_parser(return_groups: bool = False):
         default="INFO",
         help=get_field_docstring(AutotuneConfig, "console_logging_level"),
     )
+    parser.add_argument(
+        "--atomic-energies",
+        type=parse_atomic_energies,
+        default=None,
+        help=get_field_docstring(AutotuneConfig, "atomic_energies"),
+    )
 
     arg_groups = get_arg_groups()
     for g in arg_groups.values():
@@ -607,5 +627,6 @@ def parse_cli(argv):
         run_dir=args.run_dir,
         seed=args.seed,
         console_logging_level=args.log_level,
+        atomic_energies=args.atomic_energies,
     )
     return autotune_cfg

--- a/franken/autotune/script.py
+++ b/franken/autotune/script.py
@@ -58,6 +58,37 @@ warnings.filterwarnings(
 logger = logging.getLogger("franken")
 
 
+def set_dataset_atomic_energies(
+    loaders: dict[str, torch.utils.data.DataLoader],
+    atomic_energies: dict[int, float] | None,
+) -> None:
+    if atomic_energies is None:
+        return
+
+    train_dataset = loaders["train"].dataset
+    assert isinstance(train_dataset, BaseAtomsDataset)
+
+    missing_species = set(train_dataset.species) - set(atomic_energies)
+    if missing_species:
+        raise ValueError(
+            "Missing reference atomic energies for species: "
+            f"{sorted(missing_species)}"
+        )
+
+    extra_species = set(atomic_energies) - set(train_dataset.species)
+    if extra_species:
+        logger.warning(
+            "Ignoring reference atomic energies for species not present in the "
+            "training set: %s",
+            sorted(extra_species),
+        )
+
+    train_dataset.atomic_energies_ = {
+        z: atomic_energies[z] for z in train_dataset.species
+    }
+    train_dataset.energy_shifts_ = None
+
+
 def init_loaders(
     gnn_cfg: BackboneConfig,
     train_path: Path | None,
@@ -180,6 +211,8 @@ def run_autotune(
     metrics: list[str] | None = None,
     best_model_selection: list[str] | None = None,
     eval_splits: list[str] | None = None,
+    atomic_energies: dict[int, float] | None = None,
+
 ):
     if metrics is None:
         metrics = DEFAULT_AUTOTUNE_METRICS.copy()
@@ -198,7 +231,7 @@ def run_autotune(
             rf_config=rf_params,
             scale_by_Z=scale_by_species,
             num_species=loaders["train"].dataset.num_species,
-            atomic_energies=None,
+            atomic_energies=atomic_energies,
             jac_chunk_size=jac_chunk_size,
         )
 
@@ -362,6 +395,8 @@ def autotune(cfg: AutotuneConfig):
         t_end = time.time()
         logger.debug(f"Initialized data-loaders in {t_end - t_start:.2f}s")
 
+        set_dataset_atomic_energies(loaders, cfg.atomic_energies)
+
         trainer = RandomFeaturesTrainer(
             train_dataloader=loaders["train"],
             random_features_normalization=cfg.rf_normalization,
@@ -383,6 +418,8 @@ def autotune(cfg: AutotuneConfig):
             jac_chunk_size=cfg.jac_chunk_size,
             trainer=trainer,
             eval_splits=cfg.eval_splits,
+            atomic_energies=cfg.atomic_energies,
+
         )
     except Exception as e:
         logger.error("Error encountered in autotune. Exiting.", exc_info=e)

--- a/franken/config.py
+++ b/franken/config.py
@@ -419,3 +419,8 @@ class AutotuneConfig:
 
     eval_splits: Optional[list[str]] = None
     """Evaluate only the specified splits e.g. ['val', 'test']. The default value of None runs the evaluation on all splits."""
+
+    atomic_energies: dict[int, float] | None = None
+    """Optional dictionary mapping atomic numbers to their reference energies (eV).
+    If provided, these energies will be subtracted from the prediction during training.
+    Format: {atomic_number: energy_value, ...}. Example: {1: -0.5, 8: -75.3}"""

--- a/tests/test_franken_potential.py
+++ b/tests/test_franken_potential.py
@@ -516,7 +516,8 @@ class TestEnergyShift:
 
 @pytest.mark.parametrize("gnn_cfg", DEFAULT_GNN_CONFIGS)
 @pytest.mark.parametrize("device", DEVICES)
-def test_autotune(gnn_cfg, device):
+@pytest.mark.parametrize("atomic_energies", [None, {7: 1.0, 26: 10.0}])
+def test_autotune(gnn_cfg, device, atomic_energies):
     loaders = init_loaders(
         gnn_cfg,
         DATASET_REGISTRY.get_path("test", "train", None, False),
@@ -549,7 +550,9 @@ def test_autotune(gnn_cfg, device):
             loaders=loaders,
             scale_by_species=False,
             jac_chunk_size="auto",
-            trainer=trainer
+            trainer=trainer,
+            atomic_energies=atomic_energies,
+
         )
         print(f"{list(temp_dir.glob('*'))}")
         assert (temp_dir / "best.json").is_file()


### PR DESCRIPTION
Fixes #38. This update allows users to manually provide reference atomic energies. This is especially beneficial for heterogeneous systems where references values obtained from least square fitting may not be sufficient. 