### PR TITLE
Override backbone path in inference wrappers

### DIFF
--- a/franken/calculators/mace_inf_wrap.py
+++ b/franken/calculators/mace_inf_wrap.py
@@ -102,7 +102,11 @@ class MaceInferenceWrapper(torch.nn.Module):
         }
 
     @staticmethod
-    def init_wrapper(model_path: str, rf_weight_id: int | None) -> str:
+    def init_wrapper(
+        model_path: str,
+        rf_weight_id: int | None,
+        backbone_path_or_id: str | None = None,
+    ) -> str:
         """Compile a franken model into a wrapped model ready for use with MACE-LAMMPS
 
         Args:
@@ -111,6 +115,10 @@ class MaceInferenceWrapper(torch.nn.Module):
             rf_weight_id (int | None):
                 ID of the random feature weights. Can generally be left to ``None`` unless
                 the checkpoint contains multiple trained models.
+            backbone_path_or_id (str | None):
+                Override the backbone checkpoint path stored in the
+                Franken checkpoint. This is useful when paths changed
+                since training.
 
         Returns:
             str: the path where the LAMMPS-compatible model was saved to.
@@ -119,6 +127,7 @@ class MaceInferenceWrapper(torch.nn.Module):
             model_path,
             map_location=torch.device("cuda" if torch.cuda.is_available() else "cpu"),
             rf_weight_id=rf_weight_id,
+            backbone_path_or_id=backbone_path_or_id,
         )
 
         if not isinstance(franken_model.gnn, AtomisticModelWrapper):
@@ -157,13 +166,25 @@ def build_arg_parser():
         help="Head of the model to be converted to LAMMPS",
         default=None,
     )
+    parser.add_argument(
+        "--backbone_path_or_id",
+        type=str,
+        help=(
+            "Override the backbone checkpoint path stored in the " "Franken checkpoint."
+        ),
+        default=None,
+    )
     return parser
 
 
 def wrap_mace_cli():
     parser = build_arg_parser()
     args = parser.parse_args()
-    MaceInferenceWrapper.init_wrapper(args.model_path, args.rf_weight_id)  # type: ignore
+    MaceInferenceWrapper.init_wrapper(
+        args.model_path,
+        args.rf_weight_id,
+        args.backbone_path_or_id,
+    )  # type: ignore
 
 
 if __name__ == "__main__":

--- a/franken/calculators/mace_inf_wrap.py
+++ b/franken/calculators/mace_inf_wrap.py
@@ -170,7 +170,7 @@ def build_arg_parser():
         "--backbone_path_or_id",
         type=str,
         help=(
-            "Override the backbone checkpoint path stored in the " "Franken checkpoint."
+            "Override the backbone checkpoint path stored in the Franken checkpoint."
         ),
         default=None,
     )

--- a/franken/calculators/metatomic_inf_wrap.py
+++ b/franken/calculators/metatomic_inf_wrap.py
@@ -160,7 +160,10 @@ class MetatomicInferenceWrapper(torch.nn.Module):
 
 
 def create_metatomic(
-    model_path: str, rf_weight_id: int | None, dtype: torch.dtype
+    model_path: str,
+    rf_weight_id: int | None,
+    dtype: torch.dtype,
+    backbone_path_or_id: str | None = None,
 ) -> str:
     """Compile a franken model into a metatomic model wrapper
 
@@ -170,6 +173,10 @@ def create_metatomic(
         rf_weight_id (int | None):
             ID of the random feature weights. Can generally be left to ``None`` unless
             the checkpoint contains multiple trained models.
+        backbone_path_or_id (str | None):
+            Override the backbone checkpoint path stored in the
+            Franken checkpoint. This is useful when paths changed
+            since training.
 
     Returns:
         str: the path where the metatomic model was saved to.
@@ -178,6 +185,7 @@ def create_metatomic(
         model_path,
         map_location=torch.device("cpu"),
         rf_weight_id=rf_weight_id,
+        backbone_path_or_id=backbone_path_or_id,
     )
     if not isinstance(franken_model.gnn, MetatomicModelWrapper):
         raise NotImplementedError(
@@ -246,6 +254,15 @@ def build_arg_parser():
         help="Data-type in which the model will run",
         required=True,
     )
+    parser.add_argument(
+        "--backbone_path_or_id",
+        type=str,
+        help=(
+            "Override the backbone checkpoint path or registry ID stored in the "
+            "Franken checkpoint."
+        ),
+        default=None,
+    )
     return parser
 
 
@@ -253,7 +270,12 @@ def wrap_metatomic_cli():
     parser = build_arg_parser()
     args = parser.parse_args()
     dtype = torch.float32 if args.dtype == "float32" else torch.float64
-    create_metatomic(args.model_path, args.rf_weight_id, dtype)
+    create_metatomic(
+        args.model_path,
+        args.rf_weight_id,
+        dtype,
+        args.backbone_path_or_id,
+    )
 
 
 if __name__ == "__main__":

--- a/franken/rf/model.py
+++ b/franken/rf/model.py
@@ -135,11 +135,14 @@ class FrankenPotential(torch.nn.Module):
         path,
         map_location=None,
         rf_weight_id: int | None = None,
+        backbone_path_or_id: str | None = None,
     ):
         ckpt = torch.load(path, map_location=map_location, weights_only=False)
 
         rf_cfg = RFConfig.from_ckpt(ckpt["rf"]["config"])
         gnn_cfg = BackboneConfig.from_ckpt(ckpt["gnn"]["config"])
+        if backbone_path_or_id is not None:
+            gnn_cfg.path_or_id = backbone_path_or_id
         model = cls(
             gnn_config=gnn_cfg,
             rf_config=rf_cfg,

--- a/franken/rf/model.py
+++ b/franken/rf/model.py
@@ -142,6 +142,9 @@ class FrankenPotential(torch.nn.Module):
         rf_cfg = RFConfig.from_ckpt(ckpt["rf"]["config"])
         gnn_cfg = BackboneConfig.from_ckpt(ckpt["gnn"]["config"])
         if backbone_path_or_id is not None:
+            logger.warning(
+                f"The backbone path/id changed from {gnn_cfg.path_or_id} to {backbone_path_or_id}. If this refers to a different backbone, unexpected results may occur."
+            )
             gnn_cfg.path_or_id = backbone_path_or_id
         model = cls(
             gnn_config=gnn_cfg,


### PR DESCRIPTION
This PR adds a `backbone_path_or_id` override when compiling the models through the wrapper interfaces, so exported models can be created even if the backbone path stored during training no longer exists (fixes #17).

In practice, I extended the `FrankenPotential.load()` signature to override the path when loading the model and updated the wrapper CLI to accept it.

Question: should we add the same signature for the Python interfaces (ASE/torch-sim)?
In principle, this is not needed, since one could always instantiate a FrankenPotential object and use that to create the interface:
```
franken = FrankenPotential.load(
    "best_ckpt.pt",
    backbone_path_or_id="/new/path",
    map_location="cuda",
)
calc = FrankenCalculator(franken)
```
but for consistency, we could add the same option to all of them?
