### PR TITLE
Fix install dependencies

### DIFF
--- a/.github/req-dev.txt
+++ b/.github/req-dev.txt
@@ -1,1 +1,0 @@
-torch-sim-atomistic

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -71,7 +71,8 @@ jobs:
           # On the other hand it depends on them publishing the wheels
           python -m pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.0+cpu.html
           python -m pip install mace-torch
-          python -m pip install --requirement .github/req-dev.txt  # installs torch-sim
+          python -m pip install torch-sim-atomistic
+          python -m pip install metatomic-torch metatrain
 
       - name: Install package
         # conda setup requires this special shell

--- a/docs/topics/interface_torchsim.md
+++ b/docs/topics/interface_torchsim.md
@@ -13,6 +13,7 @@ This interface enables to use Franken models in [torch-sim](https://github.com/T
 
 ### Installation
 
+ - The Python interface can be installed together with franken via `pip install franken[torch-sim]`.
  - torch-sim does not publish packages on conda-forge - installation must be with pip via `pip install torch-sim-atomistic`.
  - torch-sim requires **at least python 3.12**
 

--- a/docs/topics/intro_installation.md
+++ b/docs/topics/intro_installation.md
@@ -41,11 +41,13 @@ In addition to MACE-MP0 trained on the materials project dataset, Franken also s
 ### PET
 
 Franken supports [UPET](https://github.com/lab-cosmo/upet/tree/main) models through the Metatomic/Metatrain ecosystem.
-To use PET models as a backbone for `franken`, install the required dependencies in `franken`'s environment
+To use PET models as a backbone for `franken`, install the required dependencies in `franken`'s environment.
+If you encounter an error related to the building of the  `metatrain` package, you can install it from the Github repository:
 ```bash
-pip install metatomic-torch metatrain
+pip install metatomic-torch
+pip install git+https://github.com/lab-cosmo/metatrain
 ```
-or directly install franken with PET support (`pip install franken[cuda,pet]`).
+
 
 
 ### SevenNet

--- a/docs/topics/intro_installation.md
+++ b/docs/topics/intro_installation.md
@@ -41,14 +41,7 @@ In addition to MACE-MP0 trained on the materials project dataset, Franken also s
 ### PET
 
 Franken supports [UPET](https://github.com/lab-cosmo/upet/tree/main) models through the Metatomic/Metatrain ecosystem.
-To use PET models as a backbone for `franken`, install the required dependencies in `franken`'s environment.
-If you encounter an error related to the building of the  `metatrain` package, you can install it from the Github repository:
-```bash
-pip install metatomic-torch
-pip install git+https://github.com/lab-cosmo/metatrain
-```
-
-
+To use PET models as a backbone for `franken`, install the required dependencies with `pip install franken[cuda,pet]` or follow the instructions on [metatomic](https://docs.metatensor.org/metatomic/latest/installation.html) and [metatrain](https://docs.metatensor.org/metatrain/latest/installation.html) documentation.
 
 ### SevenNet
 

--- a/docs/topics/intro_installation.md
+++ b/docs/topics/intro_installation.md
@@ -9,6 +9,7 @@ The basic installation comes bare-bones without any GNN backbone installed. You 
 ```bash
 pip install franken[cuda,mace]
 pip install franken[cuda,sevenn]
+pip install franken[cuda,pet]
 ```
 In more detail:
  - the `cuda` qualifier installs dependencies which are only relevant on GPU-enabled environments and can be omitted.
@@ -35,6 +36,16 @@ pip install mace-torch
 or directly install franken with mace support (`pip install franken[cuda,mace]`).
 
 In addition to MACE-MP0 trained on the materials project dataset, Franken also supports the [`MACE-OFF` models](https://arxiv.org/abs/2312.15211) for organic chemistry.
+
+
+### PET
+
+Franken supports [UPET](https://github.com/lab-cosmo/upet/tree/main) models through the Metatomic/Metatrain ecosystem.
+To use PET models as a backbone for `franken`, install the required dependencies in `franken`'s environment
+```bash
+pip install metatomic-torch metatrain
+```
+or directly install franken with PET support (`pip install franken[cuda,pet]`).
 
 
 ### SevenNet

--- a/franken/backbones/wrappers/base.py
+++ b/franken/backbones/wrappers/base.py
@@ -1,6 +1,5 @@
-from typing import List, Protocol, runtime_checkable
+from typing import Any, List, Protocol, runtime_checkable
 
-import metatomic.torch
 import torch
 
 from franken.data.base import Configuration
@@ -27,4 +26,6 @@ class AtomisticModelWrapper(Protocol):
 
 @runtime_checkable
 class MetatomicModelWrapper(AtomisticModelWrapper, Protocol):
-    def requested_neighbor_lists(self) -> List[metatomic.torch.NeighborListOptions]: ...
+    def requested_neighbor_lists(
+        self,
+    ) -> List[Any]: ... #metatomic.torch.NeighborListOptions

--- a/franken/backbones/wrappers/base.py
+++ b/franken/backbones/wrappers/base.py
@@ -28,4 +28,4 @@ class AtomisticModelWrapper(Protocol):
 class MetatomicModelWrapper(AtomisticModelWrapper, Protocol):
     def requested_neighbor_lists(
         self,
-    ) -> List[Any]: ... #metatomic.torch.NeighborListOptions
+    ) -> List[Any]: ...  # metatomic.torch.NeighborListOptions

--- a/franken/backbones/wrappers/mace_wrap.py
+++ b/franken/backbones/wrappers/mace_wrap.py
@@ -1,17 +1,19 @@
-from typing import Final, List, Optional, Tuple
+from typing import TYPE_CHECKING, Final, List, Optional, Tuple
 import mace
 from packaging.version import Version
 
 import torch
-import metatomic.torch
+from mace.data.neighborhood import get_neighborhood
 from mace.modules.models import MACE
 from mace.modules.utils import get_edge_vectors_and_lengths
-from mace.data.neighborhood import get_neighborhood
 from e3nn.util.jit import compile_mode
 from e3nn import o3
 
 from franken.data import Configuration
 from franken.utils.misc import torch_load_maybejit
+
+if TYPE_CHECKING:
+    import metatomic.torch
 
 
 def undo_script_mace(base: torch.jit.ScriptModule) -> MACE:
@@ -350,7 +352,11 @@ class FrankenMACE(torch.nn.Module):
     def supported_atomic_types(self) -> torch.Tensor:
         return self.atomic_numbers  # pyright: ignore[reportReturnType]
 
-    def requested_neighbor_lists(self) -> List[metatomic.torch.NeighborListOptions]:
+    def requested_neighbor_lists(
+        self,
+    ) -> List["metatomic.torch.NeighborListOptions"]:
+        import metatomic.torch
+
         return [
             metatomic.torch.NeighborListOptions(
                 cutoff=self.cutoff_radius(), full_list=True, strict=True

--- a/franken/calculators/__init__.py
+++ b/franken/calculators/__init__.py
@@ -1,11 +1,5 @@
-"""Deploy the franken model as a calculator through different interfaces.
-"""
-
-import importlib
-import importlib.util
+"""Deploy the franken model as a calculator through different interfaces."""
 
 from .ase_calc import FrankenCalculator
 
 __all__ = ("FrankenCalculator",)
-
-

--- a/franken/calculators/__init__.py
+++ b/franken/calculators/__init__.py
@@ -1,17 +1,11 @@
-"""Run molecular dynamics with learned potentials.
-
-Calculators are available for ASE and LAMMPS, but can be
-extended to support your favorite MD software.
+"""Deploy the franken model as a calculator through different interfaces.
 """
 
-from .ase_calc import FrankenCalculator
-from .mace_inf_wrap import MaceInferenceWrapper
-from .metatomic_inf_wrap import MetatomicInferenceWrapper
-from .torchsim_inf_wrap import FrankenTorchSimModel
+import importlib
+import importlib.util
 
-__all__ = (
-    "FrankenCalculator",
-    "MaceInferenceWrapper",
-    "MetatomicInferenceWrapper",
-    "FrankenTorchSimModel",
-)
+from .ase_calc import FrankenCalculator
+
+__all__ = ("FrankenCalculator",)
+
+

--- a/franken/calculators/torchsim_inf_wrap.py
+++ b/franken/calculators/torchsim_inf_wrap.py
@@ -1,156 +1,140 @@
 from pathlib import Path
-import traceback
 from typing import Any, Callable
-import warnings
 
 import torch
+import torch_sim.state
+import torch_sim.typing
+import torch_sim.transforms
+from torch_sim.models.interface import ModelInterface
+from torch_sim.neighbors import torchsim_nl
 
 from franken.backbones.wrappers.base import AtomisticModelWrapper
 from franken.data.base import Configuration
 from franken.rf.model import FrankenPotential
 
 
-try:
-    import torch_sim.state
-    import torch_sim.typing
-    import torch_sim.transforms
-    from torch_sim.models.interface import ModelInterface
-    from torch_sim.neighbors import torchsim_nl
-except ImportError:
-    warnings.warn(
-        f"torch-sim import failed: {traceback.format_exc()}",
-        stacklevel=2,
-    )
+class FrankenTorchSimModel(ModelInterface):  # type: ignore
+    """Wrap a FrankenPotential model with the torch-sim ``ModelInterface`` API.
 
-    class FrankenTorchSimModel:
-        # dummy class in case imports failed
-        def __init__(self):
-            raise
+    This adapter returns per-system energies and per-atom forces. Stress is not
+    supported.
+    """
 
-else:
+    def __init__(
+        self,
+        franken_model: FrankenPotential | str | Path,
+        *,
+        device: torch.device | str,
+        dtype: torch.dtype = torch.float32,
+        rf_weight_id: int | None = None,
+        neighbor_list_fn: Callable = torchsim_nl,
+        compute_forces: bool = True,
+        compute_stress: bool = False,
+    ) -> None:
+        super().__init__()
 
-    class FrankenTorchSimModel(ModelInterface):  # type: ignore
-        """Wrap a FrankenPotential model with the torch-sim ``ModelInterface`` API.
-
-        This adapter returns per-system energies and per-atom forces. Stress is not
-        supported.
-        """
-
-        def __init__(
-            self,
-            franken_model: FrankenPotential | str | Path,
-            *,
-            device: torch.device | str,
-            dtype: torch.dtype = torch.float32,
-            rf_weight_id: int | None = None,
-            neighbor_list_fn: Callable = torchsim_nl,
-            compute_forces: bool = True,
-            compute_stress: bool = False,
-        ) -> None:
-            super().__init__()
-
-            if compute_stress:
-                raise NotImplementedError(
-                    "FrankenTorchSimModel does not support stress in this version."
-                )
-
-            if isinstance(device, str):
-                self._device = torch.device(device)
-            else:
-                self._device = device
-            self._dtype = dtype
-            self._compute_forces = compute_forces
-            self._compute_stress = False
-            self._memory_scales_with = "n_atoms_x_density"
-            self.neighbor_list_fn = neighbor_list_fn
-
-            if isinstance(franken_model, (str, Path)):
-                self.model = FrankenPotential.load(
-                    franken_model,
-                    map_location=self._device,
-                    rf_weight_id=rf_weight_id,
-                )
-            else:
-                self.model = franken_model
-
-            if not isinstance(self.model.gnn, AtomisticModelWrapper):
-                raise NotImplementedError(
-                    f"Underlying Franken backbone does not implement AtomisticModelWrapper. Found type {type(self.model.gnn)}"
-                )
-
-            self.model = self.model.to(device=self._device, dtype=self._dtype).eval()
-            self.model.gnn.franken_val()
-
-        def forward(
-            self,
-            state: torch_sim.state.SimState | torch_sim.typing.StateLike,
-            **_kwargs: Any,
-        ) -> dict[str, torch.Tensor]:
-            """Compute energies and forces for one or more systems."""
-
-            sim_state = (
-                state
-                if isinstance(state, torch_sim.state.SimState)
-                else torch_sim.state.SimState(
-                    **state, masses=torch.ones_like(state["positions"])
-                )
+        if compute_stress:
+            raise NotImplementedError(
+                "FrankenTorchSimModel does not support stress in this version."
             )
 
-            if sim_state.device != self._device or sim_state.dtype != self._dtype:
-                sim_state = sim_state.to(device=self._device, dtype=self._dtype)
+        if isinstance(device, str):
+            self._device = torch.device(device)
+        else:
+            self._device = device
+        self._dtype = dtype
+        self._compute_forces = compute_forces
+        self._compute_stress = False
+        self._memory_scales_with = "n_atoms_x_density"
+        self.neighbor_list_fn = neighbor_list_fn
 
-            # Wrap positions into the unit cell
-            wrapped_positions = (
-                torch_sim.transforms.pbc_wrap_batched(
-                    sim_state.positions,
-                    sim_state.cell,
-                    sim_state.system_idx,
-                    sim_state.pbc,
-                )
-                if sim_state.pbc.any()
-                else sim_state.positions
+        if isinstance(franken_model, (str, Path)):
+            self.model = FrankenPotential.load(
+                franken_model,
+                map_location=self._device,
+                rf_weight_id=rf_weight_id,
             )
+        else:
+            self.model = franken_model
 
-            cutoff = torch.tensor(
-                self.model.gnn.cutoff_radius(),
-                dtype=self._dtype,
-                device=self._device,
-            )
-            # Batched neighbor list using linked-cell algorithm
-            edge_index, mapping_system, unit_shifts = self.neighbor_list_fn(
-                positions=wrapped_positions,
-                cell=sim_state.row_vector_cell,
-                pbc=sim_state.pbc,
-                cutoff=cutoff,
-                system_idx=sim_state.system_idx,
-            )
-            # Convert unit cell shift indices to Cartesian shifts
-            shifts = torch_sim.transforms.compute_cell_shifts(
-                sim_state.row_vector_cell, unit_shifts, mapping_system
+        if not isinstance(self.model.gnn, AtomisticModelWrapper):
+            raise NotImplementedError(
+                f"Underlying Franken backbone does not implement AtomisticModelWrapper. Found type {type(self.model.gnn)}"
             )
 
-            data = Configuration(
-                atom_pos=wrapped_positions,
-                atomic_numbers=sim_state.atomic_numbers,
-                natoms=torch.bincount(
-                    sim_state.system_idx, minlength=sim_state.n_systems
-                ).long(),
-                edge_index=edge_index.transpose(0, 1),
-                shifts=shifts,
-                unit_shifts=unit_shifts,
-                cell=sim_state.row_vector_cell,
-                batch_ids=sim_state.system_idx,
-                pbc=sim_state.pbc,
-            )
+        self.model = self.model.to(device=self._device, dtype=self._dtype).eval()
+        self.model.gnn.franken_val()
 
-            energy, forces = self.model(
-                data,
-                compute_forces=self._compute_forces,
-                add_energy_shift=True,
-            )
+    def forward(
+        self,
+        state: torch_sim.state.SimState | torch_sim.typing.StateLike,
+        **_kwargs: Any,
+    ) -> dict[str, torch.Tensor]:
+        """Compute energies and forces for one or more systems."""
 
-            results: dict[str, torch.Tensor] = {"energy": energy.detach().squeeze(0)}
-            if self._compute_forces:
-                assert forces is not None
-                results["forces"] = forces.detach().squeeze(0)
-            return results
+        sim_state = (
+            state
+            if isinstance(state, torch_sim.state.SimState)
+            else torch_sim.state.SimState(
+                **state, masses=torch.ones_like(state["positions"])
+            )
+        )
+
+        if sim_state.device != self._device or sim_state.dtype != self._dtype:
+            sim_state = sim_state.to(device=self._device, dtype=self._dtype)
+
+        # Wrap positions into the unit cell
+        wrapped_positions = (
+            torch_sim.transforms.pbc_wrap_batched(
+                sim_state.positions,
+                sim_state.cell,
+                sim_state.system_idx,
+                sim_state.pbc,
+            )
+            if sim_state.pbc.any()
+            else sim_state.positions
+        )
+
+        cutoff = torch.tensor(
+            self.model.gnn.cutoff_radius(),
+            dtype=self._dtype,
+            device=self._device,
+        )
+        # Batched neighbor list using linked-cell algorithm
+        edge_index, mapping_system, unit_shifts = self.neighbor_list_fn(
+            positions=wrapped_positions,
+            cell=sim_state.row_vector_cell,
+            pbc=sim_state.pbc,
+            cutoff=cutoff,
+            system_idx=sim_state.system_idx,
+        )
+        # Convert unit cell shift indices to Cartesian shifts
+        shifts = torch_sim.transforms.compute_cell_shifts(
+            sim_state.row_vector_cell, unit_shifts, mapping_system
+        )
+
+        data = Configuration(
+            atom_pos=wrapped_positions,
+            atomic_numbers=sim_state.atomic_numbers,
+            natoms=torch.bincount(
+                sim_state.system_idx, minlength=sim_state.n_systems
+            ).long(),
+            edge_index=edge_index.transpose(0, 1),
+            shifts=shifts,
+            unit_shifts=unit_shifts,
+            cell=sim_state.row_vector_cell,
+            batch_ids=sim_state.system_idx,
+            pbc=sim_state.pbc,
+        )
+
+        energy, forces = self.model(
+            data,
+            compute_forces=self._compute_forces,
+            add_energy_shift=True,
+        )
+
+        results: dict[str, torch.Tensor] = {"energy": energy.detach().squeeze(0)}
+        if self._compute_forces:
+            assert forces is not None
+            results["forces"] = forces.detach().squeeze(0)
+        return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,6 @@ dependencies = [
     "omegaconf",
     "requests",
     "docstring_parser",
-    "metatomic-torch",
-    "metatrain",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -61,6 +59,8 @@ develop = [
 ]
 mace = ["mace-torch >= 0.3.10"]
 sevenn = ["sevenn ~= 0.11"]
+pet = ["metatomic-torch", 
+       "metatrain"]
 cuda = ["cupy"]
 docs = [
     "Sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,10 @@ mace = ["mace-torch >= 0.3.10"]
 sevenn = ["sevenn ~= 0.11"]
 pet = ["metatomic-torch", 
        "metatrain"]
+torchsim = ["torch-sim-atomistic"]
+metatomic = ["metatomic-torch", 
+             "metatrain"]
+
 cuda = ["cupy"]
 docs = [
     "Sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ mace = ["mace-torch >= 0.3.10"]
 sevenn = ["sevenn ~= 0.11"]
 pet = ["metatomic-torch", 
        "metatrain"]
-torchsim = ["torch-sim-atomistic"]
+"torch-sim" = ["torch-sim-atomistic"]
 metatomic = ["metatomic-torch", 
              "metatrain"]
 

--- a/tests/test_backbones.py
+++ b/tests/test_backbones.py
@@ -16,9 +16,20 @@ from franken.rf.model import FrankenPotential
 from franken.utils.misc import no_jit
 
 # Check availability of backbones
-HAS_MACE = importlib.util.find_spec("mace") is not None
-HAS_SEVENN = importlib.util.find_spec("sevenn") is not None
-HAS_UPET = True
+def has_module(name):
+    try:
+        return importlib.util.find_spec(name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+HAS_MACE = has_module("mace")
+HAS_SEVENN = has_module("sevenn")
+HAS_UPET = (
+    has_module("metatomic.torch")
+    and has_module("metatrain.pet")
+    and has_module("vesin.metatomic")
+)
 
 # Build parametrized model list with skip marks when deps are missing
 models = []
@@ -28,7 +39,11 @@ for name in REGISTRY.keys():
     if name in {"PET_OMat/xl_1.0", "PET_OMat/l_1.0", "mace_off/large", "mace_omol/0_4M", "mace_mp/large-0b2", "mace_mp/large"}:
         marks.append(pytest.mark.skip(reason=f"{name} requires too large a model"))
         continue
-    if (kind == "mace" and not HAS_MACE) or (kind == "sevenn" and not HAS_SEVENN):
+    if (
+        (kind == "mace" and not HAS_MACE)
+        or (kind == "sevenn" and not HAS_SEVENN)
+        or (kind == "pet" and not HAS_UPET)
+    ):
         marks.append(pytest.mark.skip(reason=f"{kind} not installed"))
     elif kind == "mace":
         marks.append(pytest.mark.xfail(Version(e3nn.__version__) >= Version("0.5.5"), reason="Known incompatibility", strict=True))

--- a/tests/test_franken_calculator.py
+++ b/tests/test_franken_calculator.py
@@ -1,3 +1,7 @@
+import importlib.util
+import os
+import subprocess
+
 import ase
 import ase.md
 import numpy as np
@@ -16,9 +20,46 @@ from franken.datasets.registry import DATASET_REGISTRY
 from .conftest import DEVICES
 
 
+def has_module(name):
+    try:
+        return importlib.util.find_spec(name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+HAS_MACE = has_module("mace")
+HAS_PET = (
+    has_module("metatomic.torch")
+    and has_module("metatrain.pet")
+    and has_module("vesin.metatomic")
+)
+
+
+def compiler_supports_cxx20():
+    compiler = os.environ.get("CXX", "g++")
+    try:
+        subprocess.run(
+            [compiler, "-std=c++20", "-x", "c++", "-", "-fsyntax-only"],
+            input="int main() { return 0; }",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+    return True
+
+
 GNN_CONFIGS = [
-    MaceBackboneConfig("mace_mp/small"),
-    PETBackboneConfig("PET_MAD/xs_1.5")
+    pytest.param(
+        MaceBackboneConfig("mace_mp/small"),
+        marks=pytest.mark.skipif(not HAS_MACE, reason="MACE dependencies not installed"),
+    ),
+    pytest.param(
+        PETBackboneConfig("PET_MAD/xs_1.5"),
+        marks=pytest.mark.skipif(not HAS_PET, reason="PET dependencies not installed"),
+    ),
 ]
 
 EXPECTED_ENERGIES = {
@@ -96,6 +137,10 @@ def test_calculator_jitscript(device, gnn_cfg):
 
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("gnn_cfg", GNN_CONFIGS)
+@pytest.mark.skipif(
+    not compiler_supports_cxx20(),
+    reason="torch.compile requires a C++ compiler with C++20 support",
+)
 def test_calculator_compile(device, gnn_cfg):
     np.random.seed(1)
     torch.manual_seed(1)

--- a/tests/test_mace_inf_wrap.py
+++ b/tests/test_mace_inf_wrap.py
@@ -2,10 +2,13 @@
 Test the model conversion to LAMMPS (essentially testing torch-scriptability, not LAMMPS directly)
 """
 
+import importlib.util
 import os
 
 import pytest
 import torch
+
+pytest.importorskip("mace")
 
 from franken.backbones.wrappers.common_patches import unpatch_e3nn
 from franken.backbones.wrappers.mace_wrap import atom_numbers_to_node_attrs
@@ -26,10 +29,33 @@ RF_PARAMETRIZE = [
     MultiscaleGaussianRFConfig(num_random_features=128),
 ]
 
+def has_module(name):
+    try:
+        return importlib.util.find_spec(name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+HAS_PET = (
+    has_module("metatomic.torch")
+    and has_module("metatrain.pet")
+    and has_module("vesin.metatomic")
+)
+
+BACKBONES = [
+    pytest.param(
+        ("pet", "PET_OMat/xs_1.0"),
+        marks=pytest.mark.skipif(not HAS_PET, reason="PET dependencies not installed"),
+    ),
+    pytest.param(
+        ("mace", "mace_mp/small"),
+    ),
+]
+
 
 @pytest.mark.parametrize("rf_cfg", RF_PARAMETRIZE)
 @pytest.mark.parametrize("device", DEVICES)
-@pytest.mark.parametrize("backbone", [("pet", "PET_OMat/xs_1.0"), ("mace", "mace_mp/small")])
+@pytest.mark.parametrize("backbone", BACKBONES)
 def test_wrap_compile(rf_cfg, device, backbone):
     """Test for checking save and load methods of FrankenPotential"""
     gnn_cfg = BackboneConfig.from_ckpt(
@@ -118,7 +144,7 @@ def test_wrap_compile(rf_cfg, device, backbone):
 
 @pytest.mark.parametrize("rf_cfg", RF_PARAMETRIZE)
 @pytest.mark.parametrize("device", DEVICES)
-@pytest.mark.parametrize("backbone", [("pet", "PET_OMat/xs_1.0"), ("mace", "mace_mp/small")])
+@pytest.mark.parametrize("backbone", BACKBONES)
 def test_wrap_asemd(rf_cfg, device, backbone):
     unpatch_e3nn()  # needed in case some previous test ran the patching code
     gnn_cfg = BackboneConfig.from_ckpt(

--- a/tests/test_mace_wrap.py
+++ b/tests/test_mace_wrap.py
@@ -2,6 +2,9 @@
 
 import pytest
 import torch
+
+pytest.importorskip("mace")
+
 from mace.data import Configuration
 
 from mace.tools import AtomicNumberTable, atomic_numbers_to_indices, to_one_hot

--- a/tests/test_metatomic_inf_wrap.py
+++ b/tests/test_metatomic_inf_wrap.py
@@ -2,6 +2,7 @@
 Test the model conversion to LAMMPS (essentially testing torch-scriptability, not LAMMPS directly)
 """
 
+import importlib.util
 import os
 import pytest
 import ase
@@ -10,8 +11,17 @@ import ase.build
 import ase.units
 import numpy as np
 import torch
-from metatomic.torch import load_atomistic_model
-from metatomic.torch.ase_calculator import MetatomicCalculator
+
+metatomic_torch = pytest.importorskip("metatomic.torch")
+metatomic_ase_calculator = pytest.importorskip("metatomic.torch.ase_calculator")
+pytest.importorskip("metatensor.torch")
+pytest.importorskip("metatrain")
+
+load_atomistic_model = metatomic_torch.load_atomistic_model
+MetatomicCalculator = metatomic_ase_calculator.MetatomicCalculator
+
+HAS_MACE = importlib.util.find_spec("mace") is not None
+HAS_PET = importlib.util.find_spec("metatrain.pet") is not None
 
 from franken.backbones.wrappers.common_patches import unpatch_e3nn
 from franken.calculators.metatomic_inf_wrap import create_metatomic
@@ -30,9 +40,20 @@ RF_PARAMETRIZE = [
     MultiscaleGaussianRFConfig(num_random_features=128),
 ]
 
+BACKBONES = [
+    pytest.param(
+        ("pet", "PET_OMat/xs_1.0"),
+        marks=pytest.mark.skipif(not HAS_PET, reason="PET dependencies not installed"),
+    ),
+    pytest.param(
+        ("mace", "mace_mp/small"),
+        marks=pytest.mark.skipif(not HAS_MACE, reason="MACE dependencies not installed"),
+    ),
+]
+
 @pytest.mark.parametrize("rf_cfg", RF_PARAMETRIZE)
 @pytest.mark.parametrize("device", DEVICES)
-@pytest.mark.parametrize("backbone", [("pet", "PET_OMat/xs_1.0"), ("mace", "mace_mp/small")])
+@pytest.mark.parametrize("backbone", BACKBONES)
 def test_preserves_info(rf_cfg, device, backbone):
     """Test for checking save and load methods of FrankenPotential"""
     gnn_cfg = BackboneConfig.from_ckpt(
@@ -106,7 +127,7 @@ def test_preserves_info(rf_cfg, device, backbone):
 @pytest.mark.parametrize("rf_cfg", RF_PARAMETRIZE)
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
-@pytest.mark.parametrize("backbone", [("pet", "PET_OMat/xs_1.0"), ("mace", "mace_mp/small")])
+@pytest.mark.parametrize("backbone", BACKBONES)
 def test_calc_for_asemd(rf_cfg, device, dtype, backbone):
     gnn_cfg = BackboneConfig.from_ckpt(
         dict(family=backbone[0], path_or_id=backbone[1])

--- a/tests/test_pet_wrap.py
+++ b/tests/test_pet_wrap.py
@@ -1,5 +1,9 @@
 import torch
-import metatomic.torch
+import pytest
+
+metatomic_torch = pytest.importorskip("metatomic.torch")
+pytest.importorskip("metatrain.pet")
+pytest.importorskip("vesin.metatomic")
 
 from franken.backbones.utils import load_checkpoint
 from franken.config import PETBackboneConfig
@@ -88,7 +92,7 @@ def test_pet_systems_to_batch_accepts_precomputed_cartesian_shifts() -> None:
     species_to_species_index[1] = 0
     species_to_species_index[8] = 1
 
-    nl_options = metatomic.torch.NeighborListOptions(
+    nl_options = metatomic_torch.NeighborListOptions(
         cutoff=6.0,
         full_list=True,
         strict=True,

--- a/tests/test_torchsim_inf_wrap.py
+++ b/tests/test_torchsim_inf_wrap.py
@@ -1,8 +1,9 @@
-import traceback
-
 import pytest
 import torch
 from ase.build import molecule
+
+ts = pytest.importorskip("torch_sim")
+torch_sim_interface = pytest.importorskip("torch_sim.models.interface")
 
 from franken.calculators.torchsim_inf_wrap import FrankenTorchSimModel
 from franken.config import GaussianRFConfig, MaceBackboneConfig, PETBackboneConfig
@@ -10,15 +11,7 @@ from franken.data.base import Configuration
 from franken.rf.model import FrankenPotential
 from tests.utils import mocked_gnn
 
-
-try:
-    import torch_sim as ts
-    from torch_sim.models.interface import validate_model_outputs
-except ImportError:
-    pytest.skip(
-        f"torch-sim/metatomic not installed: {traceback.format_exc()}",
-        allow_module_level=True,
-    )
+validate_model_outputs = torch_sim_interface.validate_model_outputs
 
 
 def _build_mock_franken_model(

--- a/tests/test_transfer_perf/test_water.py
+++ b/tests/test_transfer_perf/test_water.py
@@ -19,7 +19,6 @@ import torch
 
 from franken.autotune import autotune
 from franken.calculators.ase_calc import FrankenCalculator
-from franken.calculators.torchsim_inf_wrap import FrankenTorchSimModel
 from franken.config import (
     BackboneConfig, DatasetConfig, 
     MultiscaleGaussianRFConfig, SolverConfig, HPSearchConfig, 
@@ -143,6 +142,8 @@ def batched_throughput_torchsim(
 ):
     # Test the througput of torch-sim batched model
     import torch_sim.state
+    from franken.calculators.torchsim_inf_wrap import FrankenTorchSimModel
+
     if warmup_steps >= num_steps:
         raise ValueError("warmup steps invalid")
     


### PR DESCRIPTION
## Summary

The documentation said that it was possible to install franken without backbones, but there were failing imports due to metatomic. This PR makes model/interfaces import-safe when they are not installed.

- Move `metatomic-torch`, `metatrain` out of the default dependencies and expose them through optional extras.
- Add optional install extras for PET/Metatomic and TorchSim.
- Avoid importing optional calculator backends from `franken.calculators` at package import time.
- Update optional-dependency tests to skip when the corresponding package is unavailable.

